### PR TITLE
feat(elastic6-query-service): support for terms aggregation

### DIFF
--- a/src/cores/core-types.ts
+++ b/src/cores/core-types.ts
@@ -207,6 +207,8 @@ export interface QueryResult<T> {
     page?: number;
     // limit of list.
     limit?: number;
+    // terms aggregations
+    aggregations?: any;
 }
 /**
  * class: `SimpleSearchParam`


### PR DESCRIPTION
elastic6 search service - terms aggregation 지원

query 생성 시 포함되고 있으나 결과 변환 시 aggregation 결과는 포함되지 않고 있었음