### PR TITLE
Feature/autocomplete filter

### DIFF
--- a/src/cores/core-types.ts
+++ b/src/cores/core-types.ts
@@ -258,6 +258,12 @@ export interface AutocompleteSearchParam {
         [field: string]: string;
     };
     /**
+     * additional filter object.
+     */
+    $filter?: {
+        [field: string]: string;
+    };
+    /**
      * maximum results in a page (default: 10)
      */
     $limit?: number; // limit

--- a/src/cores/elastic6-query-service.ts
+++ b/src/cores/elastic6-query-service.ts
@@ -171,13 +171,14 @@ export class Elastic6QueryService<T extends GeneralItem> implements Elastic6Simp
         const { endpoint, indexName, docType: type, autocompleteFields } = this.options;
         const { client } = Elastic6Service.instance(endpoint);
 
-        if (!param) throw new Error('@param (SimpleSearchParam) is required');
-        if (!param.$query || !Object.keys(param.$query).length) throw new Error('.query is required');
-        if (Object.keys(param.$query).length > 1) throw new Error('.query accepts only one property');
+        // validate parameters
+        if (!param) throw new Error('@param (AutocompleteSearchParam) is required');
+        if (!param.$query || !Object.keys(param.$query).length) throw new Error('.query is required.');
+        if (Object.keys(param.$query).length > 1) throw new Error('.query accepts only one property.');
 
         const [field, query] = Object.entries(param.$query)[0];
         if (!field || !query) throw new Error(`.query is invalid`);
-        if (!autocompleteFields.includes(field)) throw new Error(`.query has no autocomplete field`);
+        if (!autocompleteFields.includes(field)) throw new Error(`.query has no autocomplete field.`);
 
         // build query body
         const decomposedField = `${Elastic6Service.DECOMPOSED_FIELD}.${field}`;
@@ -189,9 +190,15 @@ export class Elastic6QueryService<T extends GeneralItem> implements Elastic6Simp
                         { match: { [decomposedField]: $hangul.asJamoSequence(query) } },
                         { match: { [qwertyField]: query } },
                     ],
+                    minimum_should_match: 1,
                 },
             },
         };
+        if (param.$filter) {
+            body.query.bool.filter = Object.entries(param.$filter).map(([field, filter]) => {
+                return { term: { [field]: filter } };
+            });
+        }
         body.size = $U.N(param.$limit, 10);
         body.from = $U.N(param.$page, 0) * body.size;
 

--- a/src/cores/elastic6-query-service.ts
+++ b/src/cores/elastic6-query-service.ts
@@ -173,12 +173,12 @@ export class Elastic6QueryService<T extends GeneralItem> implements Elastic6Simp
 
         // validate parameters
         if (!param) throw new Error('@param (AutocompleteSearchParam) is required');
-        if (!param.$query || !Object.keys(param.$query).length) throw new Error('.query is required.');
-        if (Object.keys(param.$query).length > 1) throw new Error('.query accepts only one property.');
+        if (!param.$query || !Object.keys(param.$query).length) throw new Error('.query is required');
+        if (Object.keys(param.$query).length > 1) throw new Error('.query accepts only one property');
 
         const [field, query] = Object.entries(param.$query)[0];
         if (!field || !query) throw new Error(`.query is invalid`);
-        if (!autocompleteFields.includes(field)) throw new Error(`.query has no autocomplete field.`);
+        if (!autocompleteFields.includes(field)) throw new Error(`.query has no autocomplete field`);
 
         // build query body
         const decomposedField = `${Elastic6Service.DECOMPOSED_FIELD}.${field}`;

--- a/src/cores/elastic6-service.spec.ts
+++ b/src/cores/elastic6-service.spec.ts
@@ -21,7 +21,7 @@ export const instance = () => {
     const endpoint = 'https://localhost:8443'; //NOTE - use tunneling to elastic6 endpoint.
     const indexName = 'test-v3';
     const idName = 'id';
-    const autocompleteFields = ['title'];
+    const autocompleteFields = ['title', 'name'];
     const options: Elastic6Option = { endpoint, indexName, idName, autocompleteFields };
     const service: Elastic6Service<MyModel> = new Elastic6Service<MyModel>(options);
     const dummy: Elastic6Service<MyModel> = new DummyElastic6Service<MyModel>('dummy-elastic6-data.yml', options);

--- a/src/cores/elastic6-service.ts
+++ b/src/cores/elastic6-service.ts
@@ -233,8 +233,8 @@ export class Elastic6Service<T extends Elastic6Item = any> {
         _log(NS, `- saveItem(${id})`);
 
         // prepare item body and autocomplete fields
+        this.prepareAutocompleteFields(item);
         const body: any = { ...item, [idName]: id };
-        this.prepareAutocompleteFields(body);
 
         type = `${type || docType}`;
         const params: CreateDocumentParams = {
@@ -282,8 +282,8 @@ export class Elastic6Service<T extends Elastic6Item = any> {
         const id = '';
 
         type = `${type || docType}`;
+        this.prepareAutocompleteFields(item);
         const body: any = { ...item };
-        this.prepareAutocompleteFields(body);
 
         _log(NS, `- pushItem(${id})`);
         const params: IndexDocumentParams<any> = { index: indexName, type, body };

--- a/src/cores/elastic6-service.ts
+++ b/src/cores/elastic6-service.ts
@@ -233,8 +233,8 @@ export class Elastic6Service<T extends Elastic6Item = any> {
         _log(NS, `- saveItem(${id})`);
 
         // prepare item body and autocomplete fields
-        this.prepareAutocompleteFields(item);
         const body: any = { ...item, [idName]: id };
+        this.prepareAutocompleteFields(body);
 
         type = `${type || docType}`;
         const params: CreateDocumentParams = {
@@ -252,7 +252,8 @@ export class Elastic6Service<T extends Elastic6Item = any> {
                 _log(NS, `> save[${indexName}].err =`, e instanceof Error ? e : $U.json(e));
                 if (`${e.message}`.startsWith('409 version_conflict_engine_exception')) {
                     //! try to update document...
-                    const params = { index: indexName, type, id, body: { doc: item } };
+                    delete body[idName]; // do set id while update
+                    const params = { index: indexName, type, id, body: { doc: body } };
                     return client.update(params);
                 }
                 throw e;
@@ -282,8 +283,8 @@ export class Elastic6Service<T extends Elastic6Item = any> {
         const id = '';
 
         type = `${type || docType}`;
-        this.prepareAutocompleteFields(item);
         const body: any = { ...item };
+        this.prepareAutocompleteFields(body);
 
         _log(NS, `- pushItem(${id})`);
         const params: IndexDocumentParams<any> = { index: indexName, type, body };


### PR DESCRIPTION
유레카 데이터 검수에 사용되는 자동완성 검색 사용 시
검색 대상의 stereo가 다양하여 ('group' | 'shoes' | '#') 자동완성 검색에 추가적인 필터가 필요하여 구현함.

+ ES 항목 업데이트 시 자동완성 관련 필드가 갱신되지 않는 버그 수정
