### PR TITLE
fix: fix 'fail to execute script` err

### DIFF
--- a/data/samples/os1.2/update-item.err400.script.json
+++ b/data/samples/os1.2/update-item.err400.script.json
@@ -1,0 +1,87 @@
+{
+    "!": "type mismatch error",
+    "name": "ResponseError",
+    "meta": {
+      "body": {
+        "error": {
+          "root_cause": [
+            {
+              "type": "illegal_argument_exception",
+              "reason": "failed to execute script"
+            }
+          ],
+          "type": "illegal_argument_exception",
+          "reason": "failed to execute script",
+          "caused_by": {
+            "type": "script_exception",
+            "reason": "runtime error",
+            "script_stack": [
+              "ctx._source['numberArray'] += params.increments['numberArray'];\n",
+              "                        } else {\n",
+              "                            ",
+              "                                               ^---- HERE"
+            ],
+            "script": "if (ctx._source['numberArray'] != null) {\n    ctx._source['numberArray'] += params.increments['numberArray'];\n} else {\n    ctx._source['numberArray'] = params.increments['numberArray'];\n}",
+            "lang": "painless",
+            "position": {
+              "offset": 117,
+              "start": 70,
+              "end": 195
+            },
+            "caused_by": {
+              "type": "class_cast_exception",
+              "reason": "Cannot apply [+] operation to types [java.util.ArrayList] and [java.lang.Integer]."
+            }
+          }
+        },
+        "status": 400
+      },
+      "statusCode": 400,
+      "headers": {
+        "date": "Mon, 21 Oct 2024 02:02:46 GMT",
+        "content-type": "application/json; charset=UTF-8",
+        "content-length": "717",
+        "connection": "keep-alive",
+        "access-control-allow-origin": "*"
+      },
+      "meta": {
+        "context": null,
+        "request": {
+          "params": {
+            "method": "POST",
+            "path": "/test-v1.2/_update/A1",
+            "body": "{\"upsert\":{\"numberArray\":1,\"$id\":\"A1\"},\"script\":{\"source\":\"if (ctx._source['numberArray'] != null) {\\n                            ctx._source['numberArray'] += params.increments['numberArray'];\\n                        } else {\\n                            ctx._source['numberArray'] = params.increments['numberArray'];\\n                        }\",\"lang\":\"painless\",\"params\":{\"increments\":{\"numberArray\":1}}}}",
+            "querystring": "",
+            "headers": {
+              "user-agent": "elasticsearch-js/7.12.0 (darwin 23.6.0-arm64; Node.js v18.19.1)",
+              "x-elastic-client-meta": "es=7.12.0,js=18.19.1,t=7.12.0,hc=18.19.1",
+              "content-type": "application/json",
+              "content-length": "409"
+            },
+            "timeout": 30000
+          },
+          "options": {},
+          "id": 94
+        },
+        "name": "elasticsearch-js",
+        "connection": {
+          "url": "https://localhost:9683/",
+          "id": "https://localhost:9683/",
+          "headers": {},
+          "deadCount": 0,
+          "resurrectTimeout": 0,
+          "_openRequests": 0,
+          "status": "alive",
+          "roles": {
+            "master": true,
+            "data": true,
+            "ingest": true,
+            "ml": false
+          }
+        },
+        "attempts": 0,
+        "aborted": false
+      }
+    }
+  }
+  

--- a/data/samples/os1.2/update-item.err400.script2.json
+++ b/data/samples/os1.2/update-item.err400.script2.json
@@ -1,0 +1,89 @@
+{
+    "!": "invalid character error",
+    "name": "ResponseError",
+    "meta": {
+      "body": {
+        "error": {
+          "root_cause": [
+            {
+              "type": "illegal_argument_exception",
+              "reason": "failed to execute script"
+            }
+          ],
+          "type": "illegal_argument_exception",
+          "reason": "failed to execute script",
+          "caused_by": {
+            "type": "script_exception",
+            "reason": "compile error",
+            "script_stack": [
+              "... ereo; ctx._source.account$ = params.item.account$; ...",
+              "                             ^---- HERE"
+            ],
+            "script": "ctx._source.ns = params.item.ns; ctx._source.type = params.item.type; ctx._source.stereo = params.item.stereo; ctx._source.account$ = params.item.account$; ctx._source.createdAt = params.item.createdAt; ctx._source.updatedAt = params.item.updatedAt; ctx._source.deletedAt = params.item.deletedAt; ctx._source.extra$ = params.item.extra$;",
+            "lang": "painless",
+            "position": {
+              "offset": 130,
+              "start": 105,
+              "end": 155
+            },
+            "caused_by": {
+              "type": "illegal_argument_exception",
+              "reason": "unexpected character [$].",
+              "caused_by": {
+                "type": "lexer_no_viable_alt_exception",
+                "reason": "lexer_no_viable_alt_exception: null"
+              }
+            }
+          }
+        },
+        "status": 400
+      },
+      "statusCode": 400,
+      "headers": {
+        "date": "Mon, 21 Oct 2024 04:36:24 GMT",
+        "content-type": "application/json; charset=UTF-8",
+        "content-length": "972",
+        "connection": "keep-alive",
+        "access-control-allow-origin": "*"
+      },
+      "meta": {
+        "context": null,
+        "request": {
+          "params": {
+            "method": "POST",
+            "path": "/test-v1.2/_update/T1070",
+            "body": "{\"script\":{\"source\":\"ctx._source.ns = params.item.ns; ctx._source.type = params.item.type; ctx._source.stereo = params.item.stereo; ctx._source.account$ = params.item.account$; ctx._source.createdAt = params.item.createdAt; ctx._source.updatedAt = params.item.updatedAt; ctx._source.deletedAt = params.item.deletedAt; ctx._source.extra$ = params.item.extra$;\",\"lang\":\"painless\",\"params\":{\"item\":{\"ns\":\"SS\",\"type\":\"user\",\"stereo\":\"tenant\",\"account$\":{\"openId\":\"123\",\"id\":\"123\"},\"createdAt\":\"2024-10-21T14:30:00Z\",\"updatedAt\":\"2024-10-21T14:30:00Z\",\"deletedAt\":\"0\",\"extra$\":{\"activateToken\":\"123\",\"siteId\":\"123\",\"userId\":\"123\"}}}}}",
+            "querystring": "",
+            "headers": {
+              "user-agent": "elasticsearch-js/7.12.0 (darwin 23.6.0-arm64; Node.js v18.19.1)",
+              "x-elastic-client-meta": "es=7.12.0,js=18.19.1,t=7.12.0,hc=18.19.1",
+              "content-type": "application/json",
+              "content-length": "629"
+            },
+            "timeout": 30000
+          },
+          "options": {},
+          "id": 22
+        },
+        "name": "elasticsearch-js",
+        "connection": {
+          "url": "https://localhost:9683/",
+          "id": "https://localhost:9683/",
+          "headers": {},
+          "deadCount": 0,
+          "resurrectTimeout": 0,
+          "_openRequests": 0,
+          "status": "alive",
+          "roles": {
+            "master": true,
+            "data": true,
+            "ingest": true,
+            "ml": false
+          }
+        },
+        "attempts": 0,
+        "aborted": false
+      }
+    }
+  }
+  

--- a/src/cores/elastic/elastic6-service.spec.ts
+++ b/src/cores/elastic/elastic6-service.spec.ts
@@ -24,7 +24,7 @@ const ENDPOINTS = {
     //* elastic-search */
     '6.2': 'https://localhost:8443', // run alias lmes62
     '7.1': 'https://localhost:9071', // run alias lmts071
-    '7.2': 'https://localhost:9683', // run alias lmts072
+    '7.2': 'https://localhost:9072', // run alias lmts072
     '7.10': 'https://localhost:9710', // run alias lmts710
     //* open-search */
     '1.1': 'https://localhost:8683', // run alias lmes68
@@ -2000,116 +2000,116 @@ describe('Elastic6Service', () => {
         });
     });
 
-    // //! test with real server
-    // it('should pass basic CRUD w/ real server (6.2)', async () => {
-    //     // if (!PROFILE) return; // ignore w/o profile
-    //     jest.setTimeout(1200000);
+    //! test with real server
+    it('should pass basic CRUD w/ real server (6.2)', async () => {
+        // if (!PROFILE) return; // ignore w/o profile
+        jest.setTimeout(1200000);
 
-    //     //* load dummy storage service.
-    //     const { service } = await initService('6.2');
+        //* load dummy storage service.
+        const { service } = await initService('6.2');
 
-    //     //* break if no live connection
-    //     if (!(await canPerformTest(service))) return;
+        //* break if no live connection
+        if (!(await canPerformTest(service))) return;
 
-    //     //* version check w/root
-    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
+        //* version check w/root
+        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
 
-    //     const selfTest = await service.executeSelfTest();
-    //     expect2(() => selfTest.isEqual).toEqual(true);
-    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 0 });
-    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
+        const selfTest = await service.executeSelfTest();
+        expect2(() => selfTest.isEqual).toEqual(true);
+        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 0 });
+        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
 
-    //     //* run Elastic6Service tests sequentially.
-    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    // });
+        //* run Elastic6Service tests sequentially.
+        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    });
 
-    // //! elastic storage service.
-    // it('should pass basic CRUD w/ real server(7.1)', async () => {
-    //     jest.setTimeout(1200000);
-    //     // if (!PROFILE) return; // ignore w/o profile
-    //     //* load dummy storage service.
-    //     const { service } = await initService('7.1');
+    //! elastic storage service.
+    it('should pass basic CRUD w/ real server(7.1)', async () => {
+        jest.setTimeout(1200000);
+        // if (!PROFILE) return; // ignore w/o profile
+        //* load dummy storage service.
+        const { service } = await initService('7.1');
 
-    //     //* break if no live connection
-    //     if (!(await canPerformTest(service))) return;
+        //* break if no live connection
+        if (!(await canPerformTest(service))) return;
 
-    //     //* version check w/root
-    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
+        //* version check w/root
+        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
 
-    //     const selfTest = await service.executeSelfTest();
-    //     expect2(() => selfTest.isEqual).toEqual(true);
-    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 0 });
-    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
+        const selfTest = await service.executeSelfTest();
+        expect2(() => selfTest.isEqual).toEqual(true);
+        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 0 });
+        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
 
-    //     //* run Elastic6Service tests sequentially.
-    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    // });
+        //* run Elastic6Service tests sequentially.
+        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    });
 
-    // //! elastic storage service.
-    // it('should pass basic CRUD w/ real server(7.2)', async () => {
-    //     jest.setTimeout(1200000);
-    //     // if (!PROFILE) return; // ignore w/o profile
-    //     //* load dummy storage service.
-    //     const { service } = await initService('7.2');
+    //! elastic storage service.
+    it('should pass basic CRUD w/ real server(7.2)', async () => {
+        jest.setTimeout(1200000);
+        // if (!PROFILE) return; // ignore w/o profile
+        //* load dummy storage service.
+        const { service } = await initService('7.2');
 
-    //     //* break if no live connection
-    //     if (!(await canPerformTest(service))) return;
+        //* break if no live connection
+        if (!(await canPerformTest(service))) return;
 
-    //     //* version check w/root
-    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
+        //* version check w/root
+        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
 
-    //     const selfTest = await service.executeSelfTest();
-    //     expect2(() => selfTest.isEqual).toEqual(false);
-    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 2, patch: 0 });
-    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
+        const selfTest = await service.executeSelfTest();
+        expect2(() => selfTest.isEqual).toEqual(false);
+        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 2, patch: 0 });
+        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
 
-    //     //* run Elastic6Service tests sequentially.
-    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    // });
+        //* run Elastic6Service tests sequentially.
+        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    });
 
-    // //! elastic storage service.
-    // it('should pass basic CRUD w/ real server(7.10)', async () => {
-    //     jest.setTimeout(1200000);
-    //     // if (!PROFILE) return; // ignore w/o profile
-    //     //* load dummy storage service.
-    //     const { service } = await initService('7.10');
+    //! elastic storage service.
+    it('should pass basic CRUD w/ real server(7.10)', async () => {
+        jest.setTimeout(1200000);
+        // if (!PROFILE) return; // ignore w/o profile
+        //* load dummy storage service.
+        const { service } = await initService('7.10');
 
-    //     //* break if no live connection
-    //     if (!(await canPerformTest(service))) return;
+        //* break if no live connection
+        if (!(await canPerformTest(service))) return;
 
-    //     //* version check w/root
-    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+        //* version check w/root
+        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-    //     const selfTest = await service.executeSelfTest();
-    //     expect2(() => selfTest.isEqual).toEqual(true);
-    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 0 });
-    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+        const selfTest = await service.executeSelfTest();
+        expect2(() => selfTest.isEqual).toEqual(true);
+        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 0 });
+        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-    //     //* run Elastic6Service tests sequentially.
-    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    // });
+        //* run Elastic6Service tests sequentially.
+        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    });
 
-    // //! elastic storage service.
-    // it('should pass basic CRUD w/ open-search server(1.1)', async () => {
-    //     jest.setTimeout(1200000);
-    //     // if (!PROFILE) return; // ignore w/o profile
-    //     //* load dummy storage service.
-    //     const { service } = await initService('1.1');
+    //! elastic storage service.
+    it('should pass basic CRUD w/ open-search server(1.1)', async () => {
+        jest.setTimeout(1200000);
+        // if (!PROFILE) return; // ignore w/o profile
+        //* load dummy storage service.
+        const { service } = await initService('1.1');
 
-    //     //* break if no live connection
-    //     if (!(await canPerformTest(service))) return;
+        //* break if no live connection
+        if (!(await canPerformTest(service))) return;
 
-    //     //* version check w/root
-    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+        //* version check w/root
+        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-    //     const selfTest = await service.executeSelfTest();
-    //     expect2(() => selfTest.isEqual).toEqual(false);
-    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 1, minor: 1, patch: 0 });
-    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+        const selfTest = await service.executeSelfTest();
+        expect2(() => selfTest.isEqual).toEqual(false);
+        expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 1, minor: 1, patch: 0 });
+        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-    //     //* run Elastic6Service tests sequentially.
-    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    // });
+        //* run Elastic6Service tests sequentially.
+        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    });
 
     //! elastic storage service.
     it('should pass basic CRUD w/ open-search server(1.2)', async () => {
@@ -2133,25 +2133,25 @@ describe('Elastic6Service', () => {
         expect2(await doTest(service).catch(GETERR)).toEqual('pass');
     });
 
-    // //! elastic storage service.
-    // it('should pass basic CRUD w/ open-search server(2.13)', async () => {
-    //     // if (!PROFILE) return; // ignore w/o profile
-    //     jest.setTimeout(1200000);
-    //     //* load dummy storage service.
-    //     const { service } = await initService('2.13');
+    //! elastic storage service.
+    it('should pass basic CRUD w/ open-search server(2.13)', async () => {
+        // if (!PROFILE) return; // ignore w/o profile
+        jest.setTimeout(1200000);
+        //* load dummy storage service.
+        const { service } = await initService('2.13');
 
-    //     //* break if no live connection
-    //     if (!(await canPerformTest(service))) return;
+        //* break if no live connection
+        if (!(await canPerformTest(service))) return;
 
-    //     //* version check w/root
-    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+        //* version check w/root
+        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-    //     const selfTest = await service.executeSelfTest();
-    //     expect2(() => selfTest.isEqual).toEqual(false);
-    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 2, minor: 13, patch: 0 });
-    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+        const selfTest = await service.executeSelfTest();
+        expect2(() => selfTest.isEqual).toEqual(false);
+        expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 2, minor: 13, patch: 0 });
+        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-    //     //* run Elastic6Service tests sequentially.
-    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    // });
+        //* run Elastic6Service tests sequentially.
+        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    });
 });

--- a/src/cores/elastic/elastic6-service.spec.ts
+++ b/src/cores/elastic/elastic6-service.spec.ts
@@ -272,6 +272,122 @@ export const basicCRUDTest = async (service: Elastic6Service<any>): Promise<void
     expect2(await service.readItem('A0').catch(GETERR)).toEqual('404 NOT FOUND - id:A0');
     expect2(await service.deleteItem('A0').catch(GETERR)).toEqual('404 NOT FOUND - id:A0');
 
+    //* err test
+    expect2(
+        await service.saveItem('T1070', {
+            role: 'tenant',
+            ns: 'SS',
+            account$: {
+                openId: 's533',
+                id: 'S.72379df8',
+            },
+            type: 'user',
+            accountId: 'S.723798',
+            createdAt: '172895',
+            deletedAt: '0',
+            tenant$: {
+                role: 'associate',
+                stereo: 'resident',
+                id: '10070',
+                status: 'normal',
+            },
+            stereo: 'tenant',
+            linkedAt: '1726842',
+            siteId: 'S1001',
+            updatedAt: '172046',
+        }),
+    ).toEqual({
+        $id: 'T1070',
+        _id: 'T1070',
+        _version: 1,
+        account$: { id: 'S.72379df8', openId: 's533' },
+        accountId: 'S.723798',
+        createdAt: '172895',
+        deletedAt: '0',
+        linkedAt: '1726842',
+        ns: 'SS',
+        role: 'tenant',
+        siteId: 'S1001',
+        stereo: 'tenant',
+        tenant$: { id: '10070', role: 'associate', status: 'normal', stereo: 'resident' },
+        type: 'user',
+        updatedAt: '172046',
+    });
+
+    expect2(await service.readItem('T1070')).toEqual({
+        $id: 'T1070',
+        _id: 'T1070',
+        _version: 1,
+        account$: { id: 'S.72379df8', openId: 's533' },
+        accountId: 'S.723798',
+        createdAt: '172895',
+        deletedAt: '0',
+        linkedAt: '1726842',
+        ns: 'SS',
+        role: 'tenant',
+        siteId: 'S1001',
+        stereo: 'tenant',
+        tenant$: { id: '10070', role: 'associate', status: 'normal', stereo: 'resident' },
+        type: 'user',
+        updatedAt: '172046',
+    });
+
+    expect2(
+        await service
+            .updateItem('T1070', {
+                role: 'tenant',
+                ns: 'SS',
+                account$: {
+                    openId: 'soc1734687526674533',
+                    id: 'S8',
+                },
+                airfob$: {
+                    activateToken:
+                        'eyJhbGciOi90eXBlIjoiYWN0aXZhdGVfdXNlciIsImFjY291bnRfaWQiOjIwMDAwMTc2OCwic2l0ZV9pZCI6MjAwMDAwODIzLCJzaXRlX25hbWUiOiJTTFBf6ri464-ZIiwidXNlcl9pZCI6MjAwMDQzOTAwLCJtb2JpbGUiOm51bGwsImVtYWlsIjpudWxsLCJuYW1lIjoiU0xQOlQxMDA1MjcwICgwMDAtMDAwKSDri6TsmIEiLCJwcm9wZXJ0aWVzIjp7ImRldmljZV9tYW5hZ2VyIjpmYWxzZSwibGFuZ3VhZ2UiOiJlbiJ9LCJjZXJ0aWZ5X2J5Ijoibm9uZSIsImFwcF9pZCI6MSwiaWF0IjoxNzI4OTgxMjE5LCJleHAiOjE3Mjk1ODYwMTl9.DNKVa-J6xTyenROrdRmRTd6j2Fu-jRpu39MHLRXPfpQ',
+                    siteId: '20003',
+                    userId: '2900',
+                },
+                type: 'user',
+                accountId: 'S.f8',
+                createdAt: '1895',
+                deletedAt: '0',
+                tenant$: {
+                    role: 'associate',
+                    stereo: 'resident',
+                    id: '70',
+                    status: 'normal',
+                },
+                stereo: 'tenant',
+                linkedAt: '1727842',
+                siteId: 'S101',
+                // _id: 'SS:user:T1005270',
+                // id: 'T1005270',
+                updatedAt: '11220046',
+            })
+            .catch(GETERR),
+    ).toEqual({
+        _id: 'T1070',
+        _version: 2,
+        account$: { id: 'S8', openId: 'soc1734687526674533' },
+        accountId: 'S.f8',
+        airfob$: {
+            activateToken:
+                'eyJhbGciOi90eXBlIjoiYWN0aXZhdGVfdXNlciIsImFjY291bnRfaWQiOjIwMDAwMTc2OCwic2l0ZV9pZCI6MjAwMDAwODIzLCJzaXRlX25hbWUiOiJTTFBf6ri464-ZIiwidXNlcl9pZCI6MjAwMDQzOTAwLCJtb2JpbGUiOm51bGwsImVtYWlsIjpudWxsLCJuYW1lIjoiU0xQOlQxMDA1MjcwICgwMDAtMDAwKSDri6TsmIEiLCJwcm9wZXJ0aWVzIjp7ImRldmljZV9tYW5hZ2VyIjpmYWxzZSwibGFuZ3VhZ2UiOiJlbiJ9LCJjZXJ0aWZ5X2J5Ijoibm9uZSIsImFwcF9pZCI6MSwiaWF0IjoxNzI4OTgxMjE5LCJleHAiOjE3Mjk1ODYwMTl9.DNKVa-J6xTyenROrdRmRTd6j2Fu-jRpu39MHLRXPfpQ',
+            siteId: '20003',
+            userId: '2900',
+        },
+        createdAt: '1895',
+        deletedAt: '0',
+        linkedAt: '1727842',
+        ns: 'SS',
+        role: 'tenant',
+        siteId: 'S101',
+        stereo: 'tenant',
+        tenant$: { id: '70', role: 'associate', status: 'normal', stereo: 'resident' },
+        type: 'user',
+        updatedAt: '11220046',
+    });
+
     //* create new item
     const A0 = { type: '', name: 'a0' };
     expect2(await service.saveItem('A0', A0).catch(GETERR)).toEqual({ ...A0, $id: 'A0', _id: 'A0', _version: 2 });

--- a/src/cores/elastic/elastic6-service.spec.ts
+++ b/src/cores/elastic/elastic6-service.spec.ts
@@ -24,7 +24,7 @@ const ENDPOINTS = {
     //* elastic-search */
     '6.2': 'https://localhost:8443', // run alias lmes62
     '7.1': 'https://localhost:9071', // run alias lmts071
-    '7.2': 'https://localhost:9072', // run alias lmts072
+    '7.2': 'https://localhost:9683', // run alias lmts072
     '7.10': 'https://localhost:9710', // run alias lmts710
     //* open-search */
     '1.1': 'https://localhost:8683', // run alias lmes68
@@ -278,58 +278,58 @@ export const basicCRUDTest = async (service: Elastic6Service<any>): Promise<void
             role: 'tenant',
             ns: 'SS',
             account$: {
-                openId: 's533',
-                id: 'S.72379df8',
+                openId: '123',
+                id: '123',
             },
             type: 'user',
-            accountId: 'S.723798',
-            createdAt: '172895',
+            accountId: '123',
+            createdAt: '123',
             deletedAt: '0',
             tenant$: {
                 role: 'associate',
                 stereo: 'resident',
-                id: '10070',
+                id: '123',
                 status: 'normal',
             },
             stereo: 'tenant',
-            linkedAt: '1726842',
-            siteId: 'S1001',
-            updatedAt: '172046',
+            linkedAt: '123',
+            siteId: '123',
+            updatedAt: '123',
         }),
     ).toEqual({
         $id: 'T1070',
         _id: 'T1070',
         _version: 1,
-        account$: { id: 'S.72379df8', openId: 's533' },
-        accountId: 'S.723798',
-        createdAt: '172895',
+        account$: { id: '123', openId: '123' },
+        accountId: '123',
+        createdAt: '123',
         deletedAt: '0',
-        linkedAt: '1726842',
+        linkedAt: '123',
         ns: 'SS',
         role: 'tenant',
-        siteId: 'S1001',
+        siteId: '123',
         stereo: 'tenant',
-        tenant$: { id: '10070', role: 'associate', status: 'normal', stereo: 'resident' },
+        tenant$: { id: '123', role: 'associate', status: 'normal', stereo: 'resident' },
         type: 'user',
-        updatedAt: '172046',
+        updatedAt: '123',
     });
 
     expect2(await service.readItem('T1070')).toEqual({
         $id: 'T1070',
         _id: 'T1070',
         _version: 1,
-        account$: { id: 'S.72379df8', openId: 's533' },
-        accountId: 'S.723798',
-        createdAt: '172895',
+        account$: { id: '123', openId: '123' },
+        accountId: '123',
+        createdAt: '123',
         deletedAt: '0',
-        linkedAt: '1726842',
+        linkedAt: '123',
         ns: 'SS',
         role: 'tenant',
-        siteId: 'S1001',
+        siteId: '123',
         stereo: 'tenant',
-        tenant$: { id: '10070', role: 'associate', status: 'normal', stereo: 'resident' },
+        tenant$: { id: '123', role: 'associate', status: 'normal', stereo: 'resident' },
         type: 'user',
-        updatedAt: '172046',
+        updatedAt: '123',
     });
 
     expect2(
@@ -338,54 +338,52 @@ export const basicCRUDTest = async (service: Elastic6Service<any>): Promise<void
                 role: 'tenant',
                 ns: 'SS',
                 account$: {
-                    openId: 'soc1734687526674533',
-                    id: 'S8',
+                    openId: '456',
+                    id: '456',
                 },
                 airfob$: {
-                    activateToken:
-                        'eyJhbGciOi90eXBlIjoiYWN0aXZhdGVfdXNlciIsImFjY291bnRfaWQiOjIwMDAwMTc2OCwic2l0ZV9pZCI6MjAwMDAwODIzLCJzaXRlX25hbWUiOiJTTFBf6ri464-ZIiwidXNlcl9pZCI6MjAwMDQzOTAwLCJtb2JpbGUiOm51bGwsImVtYWlsIjpudWxsLCJuYW1lIjoiU0xQOlQxMDA1MjcwICgwMDAtMDAwKSDri6TsmIEiLCJwcm9wZXJ0aWVzIjp7ImRldmljZV9tYW5hZ2VyIjpmYWxzZSwibGFuZ3VhZ2UiOiJlbiJ9LCJjZXJ0aWZ5X2J5Ijoibm9uZSIsImFwcF9pZCI6MSwiaWF0IjoxNzI4OTgxMjE5LCJleHAiOjE3Mjk1ODYwMTl9.DNKVa-J6xTyenROrdRmRTd6j2Fu-jRpu39MHLRXPfpQ',
-                    siteId: '20003',
-                    userId: '2900',
+                    activateToken: '456',
+                    siteId: '456',
+                    userId: '456',
                 },
                 type: 'user',
-                accountId: 'S.f8',
-                createdAt: '1895',
+                accountId: '456',
+                createdAt: '456',
                 deletedAt: '0',
                 tenant$: {
                     role: 'associate',
                     stereo: 'resident',
-                    id: '70',
+                    id: '456',
                     status: 'normal',
                 },
                 stereo: 'tenant',
-                linkedAt: '1727842',
-                siteId: 'S101',
-                // _id: 'SS:user:T1005270',
-                // id: 'T1005270',
-                updatedAt: '11220046',
+                linkedAt: '456',
+                siteId: '456',
+                // _id: 'T1070',
+                // id: 'T1070',
+                updatedAt: '456',
             })
             .catch(GETERR),
     ).toEqual({
         _id: 'T1070',
         _version: 2,
-        account$: { id: 'S8', openId: 'soc1734687526674533' },
-        accountId: 'S.f8',
+        account$: { id: '456', openId: '456' },
+        accountId: '456',
         airfob$: {
-            activateToken:
-                'eyJhbGciOi90eXBlIjoiYWN0aXZhdGVfdXNlciIsImFjY291bnRfaWQiOjIwMDAwMTc2OCwic2l0ZV9pZCI6MjAwMDAwODIzLCJzaXRlX25hbWUiOiJTTFBf6ri464-ZIiwidXNlcl9pZCI6MjAwMDQzOTAwLCJtb2JpbGUiOm51bGwsImVtYWlsIjpudWxsLCJuYW1lIjoiU0xQOlQxMDA1MjcwICgwMDAtMDAwKSDri6TsmIEiLCJwcm9wZXJ0aWVzIjp7ImRldmljZV9tYW5hZ2VyIjpmYWxzZSwibGFuZ3VhZ2UiOiJlbiJ9LCJjZXJ0aWZ5X2J5Ijoibm9uZSIsImFwcF9pZCI6MSwiaWF0IjoxNzI4OTgxMjE5LCJleHAiOjE3Mjk1ODYwMTl9.DNKVa-J6xTyenROrdRmRTd6j2Fu-jRpu39MHLRXPfpQ',
-            siteId: '20003',
-            userId: '2900',
+            activateToken: '456',
+            siteId: '456',
+            userId: '456',
         },
-        createdAt: '1895',
+        createdAt: '456',
         deletedAt: '0',
-        linkedAt: '1727842',
+        linkedAt: '456',
         ns: 'SS',
         role: 'tenant',
-        siteId: 'S101',
+        siteId: '456',
         stereo: 'tenant',
-        tenant$: { id: '70', role: 'associate', status: 'normal', stereo: 'resident' },
+        tenant$: { id: '456', role: 'associate', status: 'normal', stereo: 'resident' },
         type: 'user',
-        updatedAt: '11220046',
+        updatedAt: '456',
     });
 
     //* create new item
@@ -2002,116 +2000,116 @@ describe('Elastic6Service', () => {
         });
     });
 
-    //! test with real server
-    it('should pass basic CRUD w/ real server (6.2)', async () => {
-        // if (!PROFILE) return; // ignore w/o profile
-        jest.setTimeout(1200000);
+    // //! test with real server
+    // it('should pass basic CRUD w/ real server (6.2)', async () => {
+    //     // if (!PROFILE) return; // ignore w/o profile
+    //     jest.setTimeout(1200000);
 
-        //* load dummy storage service.
-        const { service } = await initService('6.2');
+    //     //* load dummy storage service.
+    //     const { service } = await initService('6.2');
 
-        //* break if no live connection
-        if (!(await canPerformTest(service))) return;
+    //     //* break if no live connection
+    //     if (!(await canPerformTest(service))) return;
 
-        //* version check w/root
-        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
+    //     //* version check w/root
+    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
 
-        const selfTest = await service.executeSelfTest();
-        expect2(() => selfTest.isEqual).toEqual(true);
-        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 0 });
-        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
+    //     const selfTest = await service.executeSelfTest();
+    //     expect2(() => selfTest.isEqual).toEqual(true);
+    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 0 });
+    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 6, minor: 2, patch: 3 });
 
-        //* run Elastic6Service tests sequentially.
-        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    });
+    //     //* run Elastic6Service tests sequentially.
+    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    // });
 
-    //! elastic storage service.
-    it('should pass basic CRUD w/ real server(7.1)', async () => {
-        jest.setTimeout(1200000);
-        // if (!PROFILE) return; // ignore w/o profile
-        //* load dummy storage service.
-        const { service } = await initService('7.1');
+    // //! elastic storage service.
+    // it('should pass basic CRUD w/ real server(7.1)', async () => {
+    //     jest.setTimeout(1200000);
+    //     // if (!PROFILE) return; // ignore w/o profile
+    //     //* load dummy storage service.
+    //     const { service } = await initService('7.1');
 
-        //* break if no live connection
-        if (!(await canPerformTest(service))) return;
+    //     //* break if no live connection
+    //     if (!(await canPerformTest(service))) return;
 
-        //* version check w/root
-        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
+    //     //* version check w/root
+    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
 
-        const selfTest = await service.executeSelfTest();
-        expect2(() => selfTest.isEqual).toEqual(true);
-        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 0 });
-        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
+    //     const selfTest = await service.executeSelfTest();
+    //     expect2(() => selfTest.isEqual).toEqual(true);
+    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 0 });
+    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 1, patch: 1 });
 
-        //* run Elastic6Service tests sequentially.
-        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    });
+    //     //* run Elastic6Service tests sequentially.
+    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    // });
 
-    //! elastic storage service.
-    it('should pass basic CRUD w/ real server(7.2)', async () => {
-        jest.setTimeout(1200000);
-        // if (!PROFILE) return; // ignore w/o profile
-        //* load dummy storage service.
-        const { service } = await initService('7.2');
+    // //! elastic storage service.
+    // it('should pass basic CRUD w/ real server(7.2)', async () => {
+    //     jest.setTimeout(1200000);
+    //     // if (!PROFILE) return; // ignore w/o profile
+    //     //* load dummy storage service.
+    //     const { service } = await initService('7.2');
 
-        //* break if no live connection
-        if (!(await canPerformTest(service))) return;
+    //     //* break if no live connection
+    //     if (!(await canPerformTest(service))) return;
 
-        //* version check w/root
-        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
+    //     //* version check w/root
+    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
 
-        const selfTest = await service.executeSelfTest();
-        expect2(() => selfTest.isEqual).toEqual(false);
-        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 2, patch: 0 });
-        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
+    //     const selfTest = await service.executeSelfTest();
+    //     expect2(() => selfTest.isEqual).toEqual(false);
+    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 2, patch: 0 });
+    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 4, patch: 2 });
 
-        //* run Elastic6Service tests sequentially.
-        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    });
+    //     //* run Elastic6Service tests sequentially.
+    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    // });
 
-    //! elastic storage service.
-    it('should pass basic CRUD w/ real server(7.10)', async () => {
-        jest.setTimeout(1200000);
-        // if (!PROFILE) return; // ignore w/o profile
-        //* load dummy storage service.
-        const { service } = await initService('7.10');
+    // //! elastic storage service.
+    // it('should pass basic CRUD w/ real server(7.10)', async () => {
+    //     jest.setTimeout(1200000);
+    //     // if (!PROFILE) return; // ignore w/o profile
+    //     //* load dummy storage service.
+    //     const { service } = await initService('7.10');
 
-        //* break if no live connection
-        if (!(await canPerformTest(service))) return;
+    //     //* break if no live connection
+    //     if (!(await canPerformTest(service))) return;
 
-        //* version check w/root
-        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+    //     //* version check w/root
+    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-        const selfTest = await service.executeSelfTest();
-        expect2(() => selfTest.isEqual).toEqual(true);
-        expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 0 });
-        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+    //     const selfTest = await service.executeSelfTest();
+    //     expect2(() => selfTest.isEqual).toEqual(true);
+    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 0 });
+    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-        //* run Elastic6Service tests sequentially.
-        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    });
+    //     //* run Elastic6Service tests sequentially.
+    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    // });
 
-    //! elastic storage service.
-    it('should pass basic CRUD w/ open-search server(1.1)', async () => {
-        jest.setTimeout(1200000);
-        // if (!PROFILE) return; // ignore w/o profile
-        //* load dummy storage service.
-        const { service } = await initService('1.1');
+    // //! elastic storage service.
+    // it('should pass basic CRUD w/ open-search server(1.1)', async () => {
+    //     jest.setTimeout(1200000);
+    //     // if (!PROFILE) return; // ignore w/o profile
+    //     //* load dummy storage service.
+    //     const { service } = await initService('1.1');
 
-        //* break if no live connection
-        if (!(await canPerformTest(service))) return;
+    //     //* break if no live connection
+    //     if (!(await canPerformTest(service))) return;
 
-        //* version check w/root
-        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+    //     //* version check w/root
+    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-        const selfTest = await service.executeSelfTest();
-        expect2(() => selfTest.isEqual).toEqual(false);
-        expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 1, minor: 1, patch: 0 });
-        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+    //     const selfTest = await service.executeSelfTest();
+    //     expect2(() => selfTest.isEqual).toEqual(false);
+    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 1, minor: 1, patch: 0 });
+    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-        //* run Elastic6Service tests sequentially.
-        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    });
+    //     //* run Elastic6Service tests sequentially.
+    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    // });
 
     //! elastic storage service.
     it('should pass basic CRUD w/ open-search server(1.2)', async () => {
@@ -2135,25 +2133,25 @@ describe('Elastic6Service', () => {
         expect2(await doTest(service).catch(GETERR)).toEqual('pass');
     });
 
-    //! elastic storage service.
-    it('should pass basic CRUD w/ open-search server(2.13)', async () => {
-        // if (!PROFILE) return; // ignore w/o profile
-        jest.setTimeout(1200000);
-        //* load dummy storage service.
-        const { service } = await initService('2.13');
+    // //! elastic storage service.
+    // it('should pass basic CRUD w/ open-search server(2.13)', async () => {
+    //     // if (!PROFILE) return; // ignore w/o profile
+    //     jest.setTimeout(1200000);
+    //     //* load dummy storage service.
+    //     const { service } = await initService('2.13');
 
-        //* break if no live connection
-        if (!(await canPerformTest(service))) return;
+    //     //* break if no live connection
+    //     if (!(await canPerformTest(service))) return;
 
-        //* version check w/root
-        expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+    //     //* version check w/root
+    //     expect2(() => service.getVersion()).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-        const selfTest = await service.executeSelfTest();
-        expect2(() => selfTest.isEqual).toEqual(false);
-        expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 2, minor: 13, patch: 0 });
-        expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
+    //     const selfTest = await service.executeSelfTest();
+    //     expect2(() => selfTest.isEqual).toEqual(false);
+    //     expect2(() => selfTest.optionVersion).toEqual({ engine: 'os', major: 2, minor: 13, patch: 0 });
+    //     expect2(() => selfTest.rootVersion).toEqual({ engine: 'es', major: 7, minor: 10, patch: 2 });
 
-        //* run Elastic6Service tests sequentially.
-        expect2(await doTest(service).catch(GETERR)).toEqual('pass');
-    });
+    //     //* run Elastic6Service tests sequentially.
+    //     expect2(await doTest(service).catch(GETERR)).toEqual('pass');
+    // });
 });

--- a/src/cores/elastic/elastic6-service.spec.ts
+++ b/src/cores/elastic/elastic6-service.spec.ts
@@ -273,117 +273,54 @@ export const basicCRUDTest = async (service: Elastic6Service<any>): Promise<void
     expect2(await service.deleteItem('A0').catch(GETERR)).toEqual('404 NOT FOUND - id:A0');
 
     //* err test
-    expect2(
-        await service.saveItem('T1070', {
-            role: 'tenant',
-            ns: 'SS',
-            account$: {
-                openId: '123',
-                id: '123',
-            },
-            type: 'user',
-            accountId: '123',
-            createdAt: '123',
-            deletedAt: '0',
-            tenant$: {
-                role: 'associate',
-                stereo: 'resident',
-                id: '123',
-                status: 'normal',
-            },
-            stereo: 'tenant',
-            linkedAt: '123',
-            siteId: '123',
-            updatedAt: '123',
-        }),
-    ).toEqual({
-        $id: 'T1070',
-        _id: 'T1070',
-        _version: 1,
-        account$: { id: '123', openId: '123' },
-        accountId: '123',
-        createdAt: '123',
-        deletedAt: '0',
-        linkedAt: '123',
+    const data = {
         ns: 'SS',
-        role: 'tenant',
-        siteId: '123',
-        stereo: 'tenant',
-        tenant$: { id: '123', role: 'associate', status: 'normal', stereo: 'resident' },
         type: 'user',
-        updatedAt: '123',
-    });
-
-    expect2(await service.readItem('T1070')).toEqual({
-        $id: 'T1070',
-        _id: 'T1070',
-        _version: 1,
-        account$: { id: '123', openId: '123' },
-        accountId: '123',
-        createdAt: '123',
+        stereo: 'tenant',
+        account$: {
+            openId: '123',
+            id: '123',
+        },
+        createdAt: '2024-10-21T14:30:00Z',
+        updatedAt: '2024-10-21T14:30:00Z',
         deletedAt: '0',
-        linkedAt: '123',
-        ns: 'SS',
-        role: 'tenant',
+    };
+    const extra$ = {
+        activateToken: '123',
         siteId: '123',
-        stereo: 'tenant',
-        tenant$: { id: '123', role: 'associate', status: 'normal', stereo: 'resident' },
-        type: 'user',
-        updatedAt: '123',
-    });
+        userId: '123',
+    };
+    // save data
+    expect2(await service.saveItem('T1070', data)).toEqual({ ...data, $id: 'T1070', _id: 'T1070', _version: 1 });
+    expect2(await service.readItem('T1070')).toEqual({ ...data, $id: 'T1070', _id: 'T1070', _version: 1 });
 
-    expect2(
-        await service
-            .updateItem('T1070', {
-                role: 'tenant',
-                ns: 'SS',
-                account$: {
-                    openId: '456',
-                    id: '456',
-                },
-                airfob$: {
-                    activateToken: '456',
-                    siteId: '456',
-                    userId: '456',
-                },
-                type: 'user',
-                accountId: '456',
-                createdAt: '456',
-                deletedAt: '0',
-                tenant$: {
-                    role: 'associate',
-                    stereo: 'resident',
-                    id: '456',
-                    status: 'normal',
-                },
-                stereo: 'tenant',
-                linkedAt: '456',
-                siteId: '456',
-                // _id: 'T1070',
-                // id: 'T1070',
-                updatedAt: '456',
-            })
-            .catch(GETERR),
-    ).toEqual({
+    // add extra$ to data
+    expect2(await service.updateItem('T1070', { ...data, extra$ })).toEqual({
+        ...data,
+        extra$,
         _id: 'T1070',
         _version: 2,
-        account$: { id: '456', openId: '456' },
-        accountId: '456',
-        airfob$: {
-            activateToken: '456',
-            siteId: '456',
-            userId: '456',
-        },
-        createdAt: '456',
-        deletedAt: '0',
-        linkedAt: '456',
-        ns: 'SS',
-        role: 'tenant',
-        siteId: '456',
-        stereo: 'tenant',
-        tenant$: { id: '456', role: 'associate', status: 'normal', stereo: 'resident' },
-        type: 'user',
-        updatedAt: '456',
+    });
+    expect2(await service.readItem('T1070')).toEqual({
+        ...data,
+        extra$,
+        _id: 'T1070',
+        $id: 'T1070',
+        _version: 2,
+    });
+    // update extra$ to null
+    expect2(await service.updateItem('T1070', { ...data, extra$: null })).toEqual({
+        ...data,
+        extra$: null,
+        _id: 'T1070',
+        _version: 3,
+    });
+    expect2(await service.readItem('T1070')).toEqual({
+        ...data,
+        extra$: null,
+        _id: 'T1070',
+        $id: 'T1070',
+        _version: 3,
     });
 
     //* create new item
@@ -713,7 +650,7 @@ export const detailedCRUDTest = async (service: Elastic6Service<CRUDModel>): Pro
     expect2(await agent().update('A1', null, { stringArray: [1.1] })).toEqual({ _version: _ver() });
     expect2(await agent().update('A1', null, { stringArray: [''] })).toEqual({ _version: _ver() });
     expect2(await agent().update('A1', null, { stringArray: 1 })).toEqual(
-        '400 ILLEGAL ARGUMENT - failed to execute script',
+        "400 ILLEGAL ARGUMENT - failed to update due to type mismatch in item's field",
     );
     expect2(await agent().update('A1', null, { stringArray: [1] })).toEqual({ _version: _ver() });
     expect2(await service.readItem('A1'), 'stringArray').toEqual({ stringArray: ['a', 'b', 'c', 1, 1.1, '', 1] });
@@ -725,7 +662,7 @@ export const detailedCRUDTest = async (service: Elastic6Service<CRUDModel>): Pro
     expect2(await agent().update('A1', null, { numberArray: [2.1, 3.1] })).toEqual({ _version: _ver() });
     expect2(await agent().update('A1', null, { numberArray: ['a'] })).toEqual('400 MAPPER PARSING');
     expect2(await agent().update('A1', null, { numberArray: 1 })).toEqual(
-        '400 ILLEGAL ARGUMENT - failed to execute script',
+        "400 ILLEGAL ARGUMENT - failed to update due to type mismatch in item's field",
     );
     expect2(await service.readItem('A1'), 'numberArray').toEqual({ numberArray: [1, 2, 3, 2.1, 3.1] });
 
@@ -742,7 +679,6 @@ export const detailedCRUDTest = async (service: Elastic6Service<CRUDModel>): Pro
     expect2(await agent().update('A1', null, { longField: ['a'] })).toEqual('400 MAPPER PARSING');
     expect2(await agent().update('A1', null, { longField: [1] })).toEqual({ _version: _ver() });
     expect2(await service.readItem('A1'), 'longField').toEqual({ longField: [1] });
-    //TODO - `_version: _ver()` use lambda to make next version number.
 
     // 4-1) float field increment test
     expect2(await agent().update('A1', null, { floatField: 0.2 })).toEqual({ _version: _ver() });

--- a/src/cores/elastic/elastic6-service.ts
+++ b/src/cores/elastic/elastic6-service.ts
@@ -897,19 +897,19 @@ export class Elastic6Service<T extends ElasticItem = any> extends ElasticIndexSe
                 if (Array.isArray(val)) {
                     // If the value is an array, append it to the existing array in the source
                     scripts.push(
-                        `if (ctx._source.${key} != null && ctx._source.${key} instanceof List) {
-                            ctx._source.${key}.addAll(params.increments.${key});
+                        `if (ctx._source['${key}'] != null && ctx._source['${key}'] instanceof List) {
+                            ctx._source['${key}'].addAll(params.increments['${key}']);
                         } else {
-                            ctx._source.${key} = params.increments.${key};
+                            ctx._source['${key}'] = params.increments['${key}'];
                         }`,
                     );
                 } else {
                     // If the value is a number, increment the existing field
                     scripts.push(
-                        `if (ctx._source.${key} != null) {
-                            ctx._source.${key} += params.increments.${key};
+                        `if (ctx._source['${key}'] != null) {
+                            ctx._source['${key}'] += params.increments['${key}'];
                         } else {
-                            ctx._source.${key} = params.increments.${key};
+                            ctx._source['${key}'] = params.increments['${key}'];
                         }`,
                     );
                 }
@@ -919,7 +919,7 @@ export class Elastic6Service<T extends ElasticItem = any> extends ElasticIndexSe
         if (item) {
             // Handle item updates in the script
             Object.entries(item).forEach(([key]) => {
-                scripts.push(`ctx._source.${key} = params.item.${key};`);
+                scripts.push(`ctx._source['${key}'] = params.item['${key}'];`);
             });
         }
 

--- a/src/cores/elastic/elastic6-service.ts
+++ b/src/cores/elastic/elastic6-service.ts
@@ -941,8 +941,14 @@ export class Elastic6Service<T extends ElasticItem = any> extends ElasticIndexSe
                 if (msg.startsWith('404 NOT FOUND')) throw new Error(`404 NOT FOUND - id:${id}`);
                 if (msg.startsWith('400 ACTION REQUEST VALIDATION')) throw e;
                 if (msg.startsWith('400 INVALID FIELD')) throw e; // at ES6.8
-                if (msg.startsWith('400 ILLEGAL ARGUMENT')) throw e; // at ES7.1
                 if (msg.startsWith('400 MAPPER PARSING')) throw e;
+                if (
+                    msg.startsWith('400 ILLEGAL ARGUMENT - Cannot apply') ||
+                    msg.startsWith('400 ILLEGAL ARGUMENT - class_cast_exception:')
+                )
+                    throw new Error(`400 ILLEGAL ARGUMENT - failed to update due to type mismatch in item's field`); // at ES7.1
+                if (msg.startsWith('400 ILLEGAL ARGUMENT')) throw e; // at ES7.1
+
                 throw E;
             }),
             // $ERROR.throwAsJson,
@@ -1349,7 +1355,10 @@ export const $ERROR = {
                 const status = $U.N(E.meta?.statusCode, type.includes('NOT FOUND') ? 404 : 400);
                 const $res = $ERROR.parseMeta<any>(E.meta);
                 //* find the reason.
-                const reason = $res.body?.error?.reason;
+                const reason =
+                    $res.body?.error?.reason === 'failed to execute script'
+                        ? $res.body?.error?.caused_by?.caused_by?.reason
+                        : $res.body?.error?.reason;
                 const result: ErrorReasonDetail = { status, type: type || (status === 404 ? 'NOT FOUND' : 'UNKNOWN') };
                 if (typeof reason !== 'undefined') {
                     result.reason = reason;


### PR DESCRIPTION
> 400 ILLEGAL ARGUMENT - failed to execute script

```
Object.entries(item).forEach(([key]) => {
                scripts.push(`ctx._source.${key} = params.item.${key};`);
            });
```
위 코드와 같은 scripts를 통해 업데이트가 이뤄지는데,
script가 특수기호`(eg. $)`를 인식하지 못하고 `fail to execute` 에러를 return 하는 것을 확인했습니다.

따라서 관련 스크립트를 수정하고, 에러가 발생한 데이터로 테스트 코드를 간단하게 추가했습니다.
더 다양한 테스트들은 이어서 추가하도록 하겠습니다.

```
ex) 에러가 발생하지 않는 경우
await service.saveItem( id, { account: { id: '1', openId: '1' }});
await service.updateItem( id, { account: { id: '2', openId: '2` }});
```
```
ex) 에러가 발생하는 경우
await service.saveItem( id, { account$: { id: '1', openId: '1' }});
await service.updateItem( id, { account$: { id: '2', openId: '2` }});

>> 400 ILLEGAL ARGUMENT - failed to execute script
```