### PR TITLE
refac: opt crypto

### DIFF
--- a/src/engine/utilities.ts
+++ b/src/engine/utilities.ts
@@ -747,6 +747,34 @@ export class Utilities {
     public readonly crypto = (passwd: string, algorithm?: string) => {
         algorithm = algorithm || 'aes-256-ctr';
         const MAGIC = 'LM!#';
+
+        /**
+         * Simulate OpenSSL's EVP_BytesToKey method
+         */
+        const evpBytesToKey = (password: Buffer, keyLen: number, ivLen: number): { key: Buffer; iv: Buffer } => {
+            let data = Buffer.alloc(0);
+            let prev = Buffer.alloc(0);
+
+            while (data.length < keyLen + ivLen) {
+                const hash = crypto.createHash('md5');
+                hash.update(Buffer.concat([prev, password]));
+                prev = hash.digest();
+                data = Buffer.concat([data, prev]);
+            }
+
+            return {
+                key: data.slice(0, keyLen),
+                iv: data.slice(keyLen, keyLen + ivLen),
+            };
+        };
+
+        const getKeyIV = () => {
+            const passwordBuf = Buffer.from(passwd, 'binary');
+            const keyLen = 32; // for aes-256
+            const ivLen = 16; // AES block size
+            return evpBytesToKey(passwordBuf, keyLen, ivLen);
+        };
+
         return new (class {
             /** @deprecated since nodejs22 */
             public encrypt = (val: string): string => {
@@ -755,22 +783,23 @@ export class Utilities {
                 //* 어느 데이터 타입이든 저장하기 위해서, object로 만든다음, 암호화 시킨다.
                 const msg = JSON.stringify({ alg: algorithm, val: val });
                 const buffer = Buffer.from(`${MAGIC}${msg || ''}`, 'utf8');
-                // const key = Buffer.from(`${passwd || ''}`, 'utf8');
-                const cipher = crypto.createCipher(algorithm, passwd);
-                // const cipher = crypto.createCipher(algorithm, passwd);
-                // const cipher = crypto.createCipheriv(algorithm, key, iv);
+
+                const { key, iv } = getKeyIV();
+                const cipher = crypto.createCipheriv(algorithm, key, iv);
                 const crypted = Buffer.concat([cipher.update(buffer), cipher.final()]);
                 return crypted.toString(1 ? 'base64' : 'utf8');
             };
             /** @deprecated since nodejs22 */
             public decrypt = (msg: string): string => {
                 const buffer = Buffer.from(`${msg || ''}`, 'base64');
-                // const key = Buffer.from(`${passwd || ''}`, 'utf8');
-                const decipher = crypto.createDecipher(algorithm, passwd);
-                // const decipher = crypto.createDecipheriv(algorithm, key, iv);
-                const dec = Buffer.concat([decipher.update(buffer), decipher.final()]).toString('utf8');
+
+                const { key, iv } = getKeyIV();
+                const decipher = crypto.createDecipheriv(algorithm, key, iv);
+                const decrypted = Buffer.concat([decipher.update(buffer), decipher.final()]);
+                const dec = decrypted.toString('utf8');
+
                 if (!dec.startsWith(MAGIC)) throw new Error('400 INVALID PASSWD - invalid magic string!');
-                const data = dec.substr(MAGIC.length);
+                const data = dec.slice(MAGIC.length);
                 if (data && !data.startsWith('{') && !data.endsWith('}'))
                     throw new Error('400 INVALID PASSWD - invalid json string!');
                 const $msg = JSON.parse(data) || {};


### PR DESCRIPTION
# crypto 개선

## 1. 문제 상황
기존에 사용하던 crypto.createCipher() 및 crypto.createDecipher()가 Node.js v22에서 제거됨

해당 API는 비밀번호 기반 암호화에 사용되었으며, 이를 사용하는 프로젝트들이 기존 암호화된 데이터를 복호화할 수 없게 되는 문제 발생

## 2. 개선 목표
- 기존과 동일한 결과를 보장
- Node.js v22 환경에서도 호환 가능하도록

## 3. 개선 내용
1. Node.js 공식 문서를 참고하여, createCipheriv() 사용이 권장되며, key/iv는 수동 생성해야 한다는 것을 확인
2. OpenSSL 문서를 통해 createCipher()는 내부적으로 `EVP_BytesToKey` 방식을 사용하여 key와 iv를 도출함을 확인
3. evpBytesToKey()을 직접 구현하여 createCipheriv()로 기존과 동일한 암호화/복호화 결과를 재현
4. 단계별 개선 요점:
    - createCipher() → createCipheriv()로 변경
    - evpBytesToKey() 함수 추가 (MD5 반복 해시 기반 key/iv 생성)

## 4. 참고 자료
[OpenSSL EVP_BytesToKey Manual](https://www.openssl.org/docs/man1.1.1/man3/EVP_BytesToKey.html) (key/iv 파생 방식 참고)
[Node.js v21 API Docs - crypto.createCipher (deprecated)](https://nodejs.org/docs/latest-v21.x/api/crypto.html#cryptocreatecipheralgorithm-password-options)
#### 리팩토링 후 기존 테스트를 모두 통과해, 호환성 검증 완료