### PR TITLE
V4 fix os connection err

### DIFF
--- a/src/cores/elastic/elastic6-service.spec.ts
+++ b/src/cores/elastic/elastic6-service.spec.ts
@@ -253,13 +253,12 @@ export const canPerformTest = async (service: Elastic6Service<MyModel>): Promise
         return true;
     } catch (e) {
         if (GETERR(e).includes('ECONNREFUSED')) return false; // no connection.
+        if (GETERR(e).includes('Connection Error')) return false; // no connection.
         //* unable to access to elastic6 endpoint
         if (GETERR(e).endsWith('unknown error')) return false;
         //* index does not exist
         if (GETERR(e).startsWith('404 NOT FOUND')) return false;
-        // console.error('! err =', e);
 
-        //* rethrow
         throw e;
     }
 };


### PR DESCRIPTION
# elastic6-service.spec connection error 개선

## 1. 문제 상황
elastic6-service 관련 테스트 수행 시, 연결이 불가능한 환경에서 `ConnectionError` 에러 발생.

기존에는 `GETERR(e).includes('ECONNREFUSED')` 조건을 통해 해당 예외를 필터링하고 테스트를 건너뛰도록 처리했으나,
최근 동일 환경에서 `ConnectionError: Connection Error` 형태의 메시지가 출력되며 기존 조건을 통과하지 못하고 테스트가 실패함을 확인.

## 2. 개선 목표
- ElasticSearch 연결 불가 시 테스트를 정상적으로 건너뛰도록 예외 필터링 로직을 보완

## 3. 개선 내용
- `elastic6-service.spec` canPerformTest() 내에 `GETERR(e).includes('Connection Error')` 조건 추가

## 4. 원인 분석
- `@elastic/elasticsearch`는 7.12 버전 공식 릴리스 노트에는 `"Connection Error"` 메시지로의 변경 관련 명시적인 기술은 없으나, 연결 오류 메시지가 `Connection Error`로 고정되어 출력되는 현상 확인
- SDK 내부에서 에러 메시지를 추상화하거나 단순화하는 방향으로 구현된 결과로 추정

## 5. 참고 자료
- [`elastic/elasticsearch-js` GitHub 리포지토리](https://github.com/elastic/elasticsearch-js)
- [Elasticsearch 7.12 released](https://www.elastic.co/blog/whats-new-elasticsearch-7-12-0-put-a-search-box-on-s3)

---

**개선 후:** 연결되지 않은 환경에서 테스트가 정상적으로 건너뛰어지며, 불필요한 테스트 실패가 발생하지 않음을 확인.
