### PR TITLE
feat: add isLambda function and update awsConfig for Lambda env handling

### DIFF
--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -10,7 +10,7 @@
  */
 import loadEnviron, { credentials } from '../environ'; //INFO! load environ first.
 import { expect2, GETERR } from '../common/test-helper';
-import { loadJsonSync, awsConfig, AwsConfigParams, onlyDefined } from './tools';
+import { loadJsonSync, awsConfig, AwsConfigParams, onlyDefined, isLambda } from './tools';
 import { fromIni } from '@aws-sdk/credential-providers';
 import $engine from '../engine';
 import { AWSSNSService } from '../cores/aws/aws-sns-service';
@@ -150,5 +150,39 @@ describe('Test tools/shared', () => {
             );
             expect2(await _sns(cfg6).catch(GETERR)).toEqual('085403634746');
         }
+    });
+
+    test('test isLambda()', () => {
+        // return false if not in Lambda environment.
+        const originalEnv = process.env.AWS_LAMBDA_FUNCTION_NAME;
+        delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+        expect2(() => isLambda()).toEqual(false);
+
+        // return true if in Lambda environment.
+        process.env.AWS_LAMBDA_FUNCTION_NAME = 'test-lambda-function';
+        expect2(() => isLambda()).toEqual(true);
+
+        // return false if empty string.
+        process.env.AWS_LAMBDA_FUNCTION_NAME = '';
+        expect2(() => isLambda()).toEqual(false);
+
+        // restore original environment.
+        if (originalEnv) process.env.AWS_LAMBDA_FUNCTION_NAME = originalEnv;
+        else delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+    });
+
+    test('test awsConfig() with Lambda environment', () => {
+        const originalEnv = process.env.AWS_LAMBDA_FUNCTION_NAME;
+
+        // simulate Lambda environment.
+        process.env.AWS_LAMBDA_FUNCTION_NAME = 'test-lambda-function';
+
+        // credentials should be undefined in Lambda environment. (profile is 'none')
+        const config = awsConfig($engine, { region: 'ap-northeast-2' });
+        expect2(() => config.credentials).toEqual(undefined); // credentials should be undefined in Lambda environment.
+
+        // restore original environment.
+        if (originalEnv) process.env.AWS_LAMBDA_FUNCTION_NAME = originalEnv;
+        else delete process.env.AWS_LAMBDA_FUNCTION_NAME;
     });
 });

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -23,6 +23,14 @@ import { RuntimeConfigAwsCredentialIdentityProvider } from '@aws-sdk/types/dist-
 // import $engine from '../engine'; #WARN! DO NOT LOAD $engine here due to global initialization.
 import { LemonEngine } from '../engine/types';
 
+/**
+ * Check if the current environment is AWS Lambda
+ * @returns {boolean} - true if running in AWS Lambda environment
+ */
+export const isLambda = (): boolean => {
+    return !!process.env.AWS_LAMBDA_FUNCTION_NAME;
+};
+
 /** returns only defined */
 export const onlyDefined = <T extends object>(N: T, $def: T = null): T =>
     N && typeof N === 'object'
@@ -108,7 +116,9 @@ export const awsConfig = <T extends AwsConfigParams>(
             ? params()
             : params?.region;
     const _conf: T = typeof params === 'object' ? params : null;
-    const profile = $engine?.environ('NAME', 'none') as string;
+
+    // If running in Lambda environment, set profile to 'none'
+    const profile = isLambda() ? 'none' : ($engine?.environ('NAME', 'none') as string);
     if (typeof profile !== 'string')
         throw new Error(`@env.NAME[${typeof profile}] is invalid (check $engine) - ${errScope}`);
 

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -28,7 +28,7 @@ import { LemonEngine } from '../engine/types';
  * @returns {boolean} - true if running in AWS Lambda environment
  */
 export const isLambda = (): boolean => {
-    return !!process.env.AWS_LAMBDA_FUNCTION_NAME;
+    return !!process?.env?.AWS_LAMBDA_FUNCTION_NAME;
 };
 
 /** returns only defined */


### PR DESCRIPTION
# AWS Lambda 환경에서 AWS Config Profile 자동 설정 기능 추가

## 변경 사항

### 1. Lambda 실행 환경 감지 로직 추가

* `isLambda()` 함수 구현
* `AWS_LAMBDA_FUNCTION_NAME` 환경 변수를 기반으로 Lambda 실행 여부 판단

### 2. `awsConfig()` 함수 로직 개선

* Lambda 환경에서는 `profile`을 자동으로 `'none'`으로 설정
* 개선된 프로필 결정 방식:

  ```ts
  const profile = isLambda() ? 'none' : ($engine?.environ('NAME', 'none') as string);
  ```
