### PR TITLE
feat/json-serialize-unit8array

### DIFF
--- a/src/cores/protocol/protocol-service.spec.ts
+++ b/src/cores/protocol/protocol-service.spec.ts
@@ -211,9 +211,13 @@ describe('ProtocolService', () => {
 
         //* now verify with real lambda call.
         if (PROFILE == 'lemon') {
-            expect2(await service.execute(param).catch(GETERR)).toEqual(
-                'Function not found: arn:aws:lambda:ap-northeast-2:085403634746:function:lemon-hello-api-dev-lambda',
-            );
+            expect2(await service.execute(param).catch(GETERR)).toEqual('404 NOT FOUND - GET /test/abc');
+
+            const helloParam = asParam('', 'hello', { id: undefined });
+            expect2(await service.execute(helloParam).catch(GETERR)).toEqual({
+                list: [{ name: 'lemon' }, { name: 'cloud' }],
+                name: 'lemon',
+            });
         }
     });
 

--- a/src/cores/protocol/protocol-service.ts
+++ b/src/cores/protocol/protocol-service.ts
@@ -352,7 +352,7 @@ export class MyProtocolService implements ProtocolService {
             })
             .then((data: InvokeCommandOutput) => {
                 _log(NS, `! execute[${param.service || ''}].res =`, $U.S(data, 320, 64, ' .... '));
-                const payload = data && data.Payload ? JSON.parse(`${data.Payload}`) : {};
+                const payload = data && data?.Payload ? JSON.parse(Buffer.from(data.Payload).toString()) : {};
                 const statusCode = $U.N(payload.statusCode || (data && data.StatusCode), 200);
                 _log(NS, `> Lambda[${params.FunctionName}].StatusCode :=`, statusCode);
                 [200, 201].includes(statusCode) || _inf(NS, `> WARN! status[${statusCode}] data =`, $U.S(data)); // print whole data if not 200.


### PR DESCRIPTION
# feat/json-serialize-unit8array

## 문제 상황

AWS Lambda의 `execute-api` 호출 결과를 JSON 파싱하는 과정에서 아래와 같은 오류 발생:

```
Unexpected token , in JSON at position 3
```

## 원인 분석

- AWS SDK for JavaScript **v3 업그레이드 이후**, `InvokeCommandOutput.Payload`의 반환 타입이 **`string` → `Uint8Array`**로 변경됨
- 기존 v2 코드에서는 `JSON.parse(data.Payload)` 호출이 가능했으나, **v3에서는 Uint8Array를 직접 JSON으로 파싱할 수 없어 오류 발생**

참고: [AWS SDK v3 InvokeCommand 문서](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/InvokeCommand/)

## 개선 사항

- `Payload` 응답을 `Buffer.from(data.Payload).toString()`으로 문자열 변환한 뒤 `JSON.parse()` 처리
관련 코드:

```ts
const payload = data?.Payload ? JSON.parse(Buffer.from(data.Payload).toString()) : {};
```
