### PR TITLE
Chore: opt my_parrallel w/ throwable option

### DIFF
--- a/src/helpers/helpers.spec.ts
+++ b/src/helpers/helpers.spec.ts
@@ -10,7 +10,7 @@
 import { loadProfile } from '../environ';
 import { $U } from '../engine';
 import { loadJsonSync } from '../tools/';
-import { expect2, waited } from '../common/test-helper';
+import { GETERR, expect2, waited } from '../common/test-helper';
 import {
     $protocol,
     $rand,
@@ -412,6 +412,56 @@ describe('utils', () => {
             { id: '1', error: 'yes error of me' },
             { id: '2', error: null, data: 2 },
         ]);
+
+        const result3 = await my_parrallel(
+            [
+                { id: '1', error: 'me' },
+                { id: '2', error: null },
+                { id: undefined, error: 'me2' },
+            ],
+            async (item: MyModel, i) => {
+                if (item?.error) throw new Error(`yes error of ${item?.error}`);
+                const data = i + 1;
+                return { ...item, data };
+            },
+            10,
+            { throwable: true },
+        ).catch(GETERR);
+        expect2(() => result3).toEqual(
+            'my_parrallel Task T(S/F): 3(1/2) - func()\n' +
+                'Failed tasks:\n' +
+                '  - 1: yes error of me\n' +
+                '  - N/A: yes error of me2',
+        );
+
+        //* test throwable=false (no error thrown)
+        const result4 = await my_parrallel(
+            [
+                { id: 'a', error: 'fail' },
+                { id: 'b', error: null },
+            ],
+            async (item: MyModel) => {
+                if (item?.error) throw new Error(`error: ${item?.error}`);
+                return { ...item, data: 100 };
+            },
+            10,
+            { throwable: false },
+        );
+        expect2(() => result4).toEqual([{ id: 'a', error: 'error: fail' }, { id: 'b', error: null, data: 100 }]);
+
+        //* test with custom errScope
+        const result5 = await my_parrallel(
+            [{ id: 'x', error: 'test' }],
+            async (item: MyModel) => {
+                if (item?.error) throw new Error(`failed`);
+                return item;
+            },
+            10,
+            { throwable: true, errScope: 'customScope()' },
+        ).catch(GETERR);
+        expect2(() => result5).toEqual(
+            'my_parrallel Task T(S/F): 1(0/1) - customScope()\n' + 'Failed tasks:\n' + '  - x: failed',
+        );
     });
 
     it('should pass my_sequence()', async () => {

--- a/src/helpers/helpers.spec.ts
+++ b/src/helpers/helpers.spec.ts
@@ -374,24 +374,26 @@ describe('utils', () => {
 
     //* test of my_parrallel()
     it('should pass my_parrallel()', async () => {
-        interface MyModel {
-            id: string;
-            error: string;
+        interface T {
+            id?: string;
+            error?: string | null;
             data?: number;
         }
+
         //* test with async function.
-        const results = await my_parrallel(
+        const results1 = await my_parrallel<T, T>(
             [
                 { id: '1', error: 'me' },
                 { id: '2', error: null },
             ],
-            async (item: MyModel, i) => {
+            async (item: T, i) => {
                 if (item?.error) throw new Error(`yes error of ${item?.error}`);
                 const data = i + 1;
                 return { ...item, data };
             },
-        );
-        expect2(() => results).toEqual([
+            { throwable: false },
+        ).catch(GETERR);
+        expect2(() => results1).toEqual([
             { id: '1', error: 'yes error of me' },
             { id: '2', error: null, data: 2 },
         ]);
@@ -402,37 +404,78 @@ describe('utils', () => {
                 { id: '1', error: 'me' },
                 { id: '2', error: null },
             ],
-            (item: MyModel, i): any => {
+            (item: T, i): any => {
                 if (item?.error) throw new Error(`yes error of ${item?.error}`);
                 const data = i + 1;
                 return { ...item, data };
             },
-        );
+            { throwable: false },
+        ).catch(GETERR);
         expect2(() => results2).toEqual([
             { id: '1', error: 'yes error of me' },
             { id: '2', error: null, data: 2 },
         ]);
 
-        const result3 = await my_parrallel(
-            [
-                { id: '1', error: 'me' },
-                { id: '2', error: null },
-                { id: undefined, error: 'me2' },
-            ],
-            async (item: MyModel, i) => {
-                if (item?.error) throw new Error(`yes error of ${item?.error}`);
-                const data = i + 1;
-                return { ...item, data };
-            },
-            10,
-            { throwable: true },
-        ).catch(GETERR);
-        expect2(() => result3).toEqual(
-            'my_parrallel Task T(S/F): 3(1/2) - func()\n' +
-                'Failed tasks:\n' +
-                '  - 1: yes error of me\n' +
-                '  - N/A: yes error of me2',
+        class AppError extends Error {
+            constructor(message: string, public readonly cause?: unknown) {
+                super(message);
+                this.name = 'AppError';
+            }
+        }
+        function formatError(err: unknown, prefix = '', delim = '  '): string {
+            let output = '';
+            let current = err;
+            while (current instanceof Error) {
+                output += `${prefix}${current.name}: ${current.message}\n`;
+                current = (current as any).cause;
+                if (current && Array.isArray(current)) {
+                    output += current.map(e => formatError(e, prefix + delim, delim)).join('\n');
+                    continue;
+                }
+            }
+            return output.trim();
+        }
+        expect2(() =>
+            formatError(
+                new AppError(
+                    'level1',
+                    new AppError('level2', [new AppError('level3-1', new Error('level4')), new Error('level3-2')]),
+                ),
+            ),
+        ).toEqual(`AppError: level1\nAppError: level2\nAppError: level3-1\n  Error: level4\nError: level3-2`);
+
+        //* test throwable=true (error thrown)
+        const case3List: T[] = [
+            { id: '1', error: 'me' },
+            { id: '2', error: null, data: 1 },
+            { id: undefined, error: 'me2' },
+            { id: '4', data: 4 },
+        ];
+        const func3Async = async (item: T, i: number) => {
+            if (item?.error) throw new Error(`yes error of ${item?.error}`);
+            const data = i + 1;
+            return { ...item, data };
+        };
+        const result3E = await my_parrallel(case3List, func3Async, { throwable: true }).catch(e => formatError(e));
+        expect2(() => result3E).toEqual(
+            `MyError: yes error of me (+1 more errors) (S:2/4) - parrallel(10)
+MyError: yes error of me
+  Error: yes error of me
+MyError: yes error of me2
+  Error: yes error of me2
+`.trim(),
         );
+        const result3D = await my_parrallel(case3List, func3Async).catch(e => formatError(e));
+        expect2(() => result3D).toEqual(result3E);
+
+        //* test throwable=false (no error thrown)
+        const result3S = await my_parrallel(case3List, func3Async, { throwable: false }).catch(GETERR);
+        expect2(() => result3S).toEqual([
+            { id: '1', error: 'yes error of me' },
+            { id: '2', error: null, data: 2 },
+            { id: undefined, error: 'yes error of me2' },
+            { id: '4', data: 4 },
+        ]);
 
         //* test throwable=false (no error thrown)
         const result4 = await my_parrallel(
@@ -440,47 +483,46 @@ describe('utils', () => {
                 { id: 'a', error: 'fail' },
                 { id: 'b', error: null },
             ],
-            async (item: MyModel) => {
+            (item: any) => {
                 if (item?.error) throw new Error(`error: ${item?.error}`);
                 return { ...item, data: 100 };
             },
-            10,
             { throwable: false },
         );
-        expect2(() => result4).toEqual([{ id: 'a', error: 'error: fail' }, { id: 'b', error: null, data: 100 }]);
+        expect2(() => result4).toEqual([
+            { id: 'a', error: 'error: fail' },
+            { id: 'b', error: null, data: 100 },
+        ]);
 
         //* test with custom errScope
         const result5 = await my_parrallel(
             [{ id: 'x', error: 'test' }],
-            async (item: MyModel) => {
+            (item: any) => {
                 if (item?.error) throw new Error(`failed`);
                 return item;
             },
-            10,
             { throwable: true, errScope: 'customScope()' },
         ).catch(GETERR);
-        expect2(() => result5).toEqual(
-            'my_parrallel Task T(S/F): 1(0/1) - customScope()\n' + 'Failed tasks:\n' + '  - x: failed',
-        );
+        expect2(() => result5).toEqual('failed (S:0/1) - customScope()');
     });
 
     it('should pass my_sequence()', async () => {
-        interface MyModel {
-            id: string;
-            error: string;
+        interface T {
+            id?: string;
+            error?: string | null;
             data?: number;
             actionTime?: number;
         }
         const actionDelay = 100; // milliseconds
         //* test with async function.
-        const results = await my_sequence(
+        const results = await my_sequence<T, T>(
             [
                 { id: '1', error: null },
                 { id: '2', error: null },
                 { id: '3', error: null },
                 { id: '4', error: null },
             ],
-            async (item: MyModel, i) => {
+            async (item: T, i) => {
                 const actionTime = new Date().getTime();
                 await waited(actionDelay);
                 return { ...item, actionTime };
@@ -497,7 +539,7 @@ describe('utils', () => {
         // compare action time of each task by order sequence
         results.forEach(result => {
             expect2(() => result.actionTime).toBeGreaterThan(previousActionTime + actionDelay - 0.1);
-            previousActionTime = result.actionTime;
+            previousActionTime = result.actionTime ?? 0;
         });
     });
 

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -436,8 +436,13 @@ export const $protocol = (
     const execute = <T = any>(param?: any, body?: any, mode: string = 'POST'): Promise<T> =>
         $proto.execute($param(param, body, { mode }));
     // eslint-disable-next-line prettier/prettier
-    const enqueue = <T=any>(param?: any, body?: any, mode: string = 'POST', callback?: string, delaySeconds: number = 1): Promise<string> =>
-        $proto.enqueue($param(param, body, { mode }), $callback(callback), delaySeconds);
+    const enqueue = <T = any>(
+        param?: any,
+        body?: any,
+        mode: string = 'POST',
+        callback?: string,
+        delaySeconds: number = 1,
+    ): Promise<string> => $proto.enqueue($param(param, body, { mode }), $callback(callback), delaySeconds);
     const notify = (param?: any, body?: any, mode: string = 'POST', callback?: string): Promise<string> =>
         $proto.notify($param(param, body, { mode }), $callback(callback));
 
@@ -603,7 +608,42 @@ export const my_parrallel = async <
     list: T[],
     func: (item: T, index?: number) => Promise<U>,
     size?: number,
+    options?: {
+        /** throw error if any item fails (default: false) */
+        throwable?: boolean;
+        /** error scope for context tracking */
+        errScope?: string;
+        /** report to slack when completed (default: false) - TODO */
+        reportSlack?: boolean;
+        /** context for slack reporting */
+        context?: NextContext;
+    },
 ) => {
+    type MyParrallelError = { id?: string; error: string };
+    const throwable = options?.throwable ?? false;
+    const errScope = options?.errScope ?? 'func()';
+
+    //* inner: collect and analyze errors
+    const handleErrors = (results: any[]): void => {
+        const errors = results.filter(
+            (r): r is MyParrallelError => r && typeof r === 'object' && 'error' in r && typeof r.error === 'string',
+        );
+        //* calculate statistics
+        const total = $T.N(list.length);
+        const failed = $T.N(errors.length);
+        const success = $T.N(total - failed);
+
+        //* build error message
+        const summaryLine = `my_parrallel Task T(S/F): ${total}(${success}/${failed}) - ${errScope}`;
+        const failureDetails =
+            failed > 0 ? ['Failed tasks:', ...errors.map(e => `  - ${e.id ?? 'N/A'}: ${e.error}`)] : [];
+        const msg = [summaryLine, ...failureDetails].join('\n');
+
+        //* throw if throwable and has errors
+        if (failed > 0 && throwable) throw new Error(msg);
+    };
+
+    //* run parallel execution
     const results = await do_parrallel(
         list,
         (item, i) => {
@@ -619,6 +659,9 @@ export const my_parrallel = async <
         },
         size,
     );
+    //* analyze and handle errors
+    if (throwable) handleErrors(results);
+
     return results as unknown as U[];
 };
 
@@ -711,7 +754,11 @@ export const createSigV4Proxy = (
 
             //* prepare request parameters
             // eslint-disable-next-line prettier/prettier
-            const query_string = _isNa($param) ? '' : (typeof $param == 'object' ? queryString.stringify($param) : `${$param}`);
+            const query_string = _isNa($param)
+                ? ''
+                : typeof $param == 'object'
+                ? queryString.stringify($param)
+                : `${$param}`;
             const url =
                 endpoint +
                 (_isNa(path1) ? '' : `/${encoder('host', path1)}`) +

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -539,7 +539,7 @@ export const $event = (context: NextContext, defEndpoint: string = '') => {
  * authentication helper - get identity-id from context
  * @param context the current context
  */
-export function getIdentityId(context: NextContext): string | undefined {
+export function getIdentityId(context?: NextContext | null): string | undefined {
     const identityId = (context?.identity as NextIdentityCognito)?.identityId;
     if (!identityId && context?.domain === 'localhost') {
         //* use `env[LOCAL_ACCOUNT]` only if runs in local server.
@@ -599,49 +599,34 @@ export function parseRange(exp: string): any {
  *
  * @param list list of model.
  * @param func callback to process of each
- * @param size (optional) size of parrallel (default 10)
+ * @param params (optional) size of parrallel (default 10) or options. (for comparibility with `do_parrallel()`)
  */
 export const my_parrallel = async <
-    T extends { id?: string; error?: string },
-    U extends { id?: string; error?: string },
+    T extends { id?: string; error?: string | null },
+    U extends { id?: string; error?: string | null },
 >(
     list: T[],
-    func: (item: T, index?: number) => Promise<U>,
-    size?: number,
-    options?: {
-        /** throw error if any item fails (default: false) */
-        throwable?: boolean;
-        /** error scope for context tracking */
-        errScope?: string;
-        /** report to slack when completed (default: false) - TODO */
-        reportSlack?: boolean;
-        /** context for slack reporting */
-        context?: NextContext;
-    },
+    func: (item: T, index: number) => Promise<U>,
+    params?:
+        | number
+        | {
+              /** size of parallel execution (default 10) */
+              size?: number;
+              /** throw error if any item fails (default: false) */
+              throwable?: boolean;
+              /** error scope for context tracking */
+              errScope?: string;
+              /** report to slack when completed (default: false) - TODO */
+              reportSlack?: boolean;
+              /** context for slack reporting */
+              context?: NextContext;
+          },
 ) => {
-    type MyParrallelError = { id?: string; error: string };
-    const throwable = options?.throwable ?? false;
-    const errScope = options?.errScope ?? 'func()';
-
-    //* inner: collect and analyze errors
-    const handleErrors = (results: any[]): void => {
-        const errors = results.filter(
-            (r): r is MyParrallelError => r && typeof r === 'object' && 'error' in r && typeof r.error === 'string',
-        );
-        //* calculate statistics
-        const total = $T.N(list.length);
-        const failed = $T.N(errors.length);
-        const success = $T.N(total - failed);
-
-        //* build error message
-        const summaryLine = `my_parrallel Task T(S/F): ${total}(${success}/${failed}) - ${errScope}`;
-        const failureDetails =
-            failed > 0 ? ['Failed tasks:', ...errors.map(e => `  - ${e.id ?? 'N/A'}: ${e.error}`)] : [];
-        const msg = [summaryLine, ...failureDetails].join('\n');
-
-        //* throw if throwable and has errors
-        if (failed > 0 && throwable) throw new Error(msg);
-    };
+    const options = typeof params === 'number' ? { size: params } : params || {};
+    const size = options?.size ?? 10;
+    const throwable = options?.throwable ?? true;
+    const errScope = options?.errScope ?? `parrallel(${size})`;
+    if (!list?.length) return [];
 
     //* run parallel execution
     const results = await do_parrallel(
@@ -655,14 +640,45 @@ export const my_parrallel = async <
                 }
             })();
             const res = ret instanceof Promise ? ret : Promise.resolve(ret);
-            return res.catch(e => ({ id: item.id, error: GETERR(e) }));
+            return res.catch(e => ({ id: item.id, error: e instanceof Error ? e : new Error(e) }));
         },
         size,
     );
-    //* analyze and handle errors
-    if (throwable) handleErrors(results);
 
-    return results as unknown as U[];
+    //* analyze and handle errors
+    const errors = results
+        .map<Error>((N: any) => N?.error)
+        .filter(e => (typeof e === 'object' && e instanceof Error ? true : false));
+    //* calculate statistics
+    const total = $T.N(list.length);
+    const failed = $T.N(errors.length);
+    const success = $T.N(total - failed);
+
+    class MyError extends Error {
+        constructor(message: string, public readonly cause?: unknown) {
+            super(message);
+            this.name = 'MyError';
+        }
+    }
+    //* build error message
+    if (throwable && failed > 0) {
+        const msg = GETERR(errors[0]);
+        const cnt = failed > 1 ? ` (+${failed - 1} more errors)` : '';
+        throw new MyError(
+            `${msg}${cnt} (S:${success}/${total}) - ${errScope}`,
+            errors?.map(e => new MyError(GETERR(e), e)),
+        );
+    }
+
+    //* make sure to transform error objects.
+    return results.map<U>((N: any) =>
+        N?.error === undefined
+            ? N
+            : {
+                  ...N,
+                  error: N?.error === null ? null : GETERR(N.error),
+              },
+    );
 };
 
 /**
@@ -674,10 +690,10 @@ export const my_parrallel = async <
  * @param list list of model.
  * @param func callback to process of each
  */
-export const my_sequence = <T extends { id?: string; error?: string }, U = T>(
+export const my_sequence = <T extends { id?: string; error?: string | null }, U = T>(
     list: T[],
     func: (item: T, index?: number) => Promise<U>,
-) => my_parrallel(list, func, 1);
+) => my_parrallel<T, U>(list, func, 1);
 
 /**
  * create api-http-proxy with sig-v4 agent, which using endpoint as proxy server.
@@ -714,7 +730,7 @@ export const createSigV4Proxy = (
 ): ApiHttpProxy => {
     const errScope = `createSigV4Proxy(${name ?? ''})`;
     if (!endpoint) throw new Error(`@endpoint (url) is required - ${errScope}`);
-    const NS = $U.NS(`X${name}`, 'magenta'); // NAMESPACE TO BE PRINTED.
+    const NS = $U.NS(`X${name ?? ''}`, 'magenta'); // NAMESPACE TO BE PRINTED.
     const encoder = options?.encoder ?? ((name, path) => path);
     const relayHeaderKey = options?.relayHeaderKey ?? '';
     const resultKey = options?.resultKey ?? '';


### PR DESCRIPTION
## Goals
- `my_parrallel()` 함수의 에러 처리 및 리포팅 기능 개선

## Tasks
- throwable 옵션 추가로 에러 전파 제어 가능하도록 개선
- errScope 옵션 추가로 실행 컨텍스트 추적 지원
- 스펙 기반 검증 추가

## Todo
- 결과 슬랙 리포팅 지원