### PR TITLE
Feat/add dynamo multiple operations

### DIFF
--- a/src/cores/dynamo/dynamo-service.spec.ts
+++ b/src/cores/dynamo/dynamo-service.spec.ts
@@ -152,7 +152,7 @@ describe('DynamoService', () => {
         //* load dummy storage service.
         const { dummy, tableName } = instance();
 
-        it('should pass basic CRUD', async () => {
+        it('should pass mutiple crud operations with dummy', async () => {
             //* check dummy data.
             expect2(dummy.hello()).toEqual(`dummy-dynamo-service:${tableName}`);
 
@@ -172,14 +172,391 @@ describe('DynamoService', () => {
             expect2(await dummy.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: null });
             expect2(await dummy.updateItem('A0', 0, { type: 'account' }).catch(GETERR), 'ID').toEqual({ ID: 'A0' });
             expect2(await dummy.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: 'account' });
-        });
 
-        it('should pass simple list w/ dummy', async () => {
-            //* check dummy data.
+            //* check dummy data list
             expect2(dummy.hello()).toEqual(`dummy-dynamo-service:${tableName}`);
             expect2(await dummy.listItems(), '!list').toEqual({ page: 1, limit: 2, total: 3 });
             expect2(await dummy.listItems(1, 1), '!list').toEqual({ page: 1, limit: 1, total: 3 });
             expect2(await dummy.listItems(2, 2), '!list').toEqual({ page: 2, limit: 2, total: 3 });
+
+            //* msaveItem test
+            {
+                // 1. validate list parameter
+                //* null list
+                const nullResult = await dummy.msaveItem(null as any);
+                expect2(() => nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* undefined list
+                const undefinedResult = await dummy.msaveItem(undefined as any);
+                expect2(() => undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* empty list
+                const emptyResult = await dummy.msaveItem([]);
+                expect2(() => emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // 2. success cases
+                //* single item save
+                const singleItem = [{ id: 'S0', type: 'product', name: 'Item A' }];
+                const singleResult = await dummy.msaveItem(singleItem);
+                expect2(() => singleResult, 'total').toEqual({ total: 1 });
+                expect2(() => singleResult.success.length).toEqual(1);
+                expect2(() => singleResult.failed.length).toEqual(0);
+                expect2(() => singleResult.success[0], 'ID,type,name').toEqual({
+                    ID: 'S0',
+                    type: 'product',
+                    name: 'Item A',
+                });
+
+                //* verify saved item
+                expect2(await dummy.readItem('S0'), 'ID,type,name').toEqual({
+                    ID: 'S0',
+                    type: 'product',
+                    name: 'Item A',
+                });
+
+                //* multiple items save (small batch < 25)
+                const multipleItems = [
+                    { id: 'S1', type: 'product', name: 'Item B' },
+                    { id: 'S2', type: 'product', name: 'Item C' },
+                    { id: 'S3', type: 'service', name: 'Item D' },
+                ];
+                const multipleResult = await dummy.msaveItem(multipleItems);
+                expect2(() => multipleResult, 'total').toEqual({ total: 3 });
+                expect2(() => multipleResult.success.length).toEqual(3);
+                expect2(() => multipleResult.failed.length).toEqual(0);
+
+                //* verify all saved items
+                expect2(await dummy.readItem('S1'), 'ID,type,name').toEqual({
+                    ID: 'S1',
+                    type: 'product',
+                    name: 'Item B',
+                });
+                expect2(await dummy.readItem('S2'), 'ID,type,name').toEqual({
+                    ID: 'S2',
+                    type: 'product',
+                    name: 'Item C',
+                });
+                expect2(await dummy.readItem('S3'), 'ID,type,name').toEqual({
+                    ID: 'S3',
+                    type: 'service',
+                    name: 'Item D',
+                });
+
+                //* overwrite existing items
+                const overwriteItems = [
+                    { id: 'S1', type: 'service', name: 'Item B Updated' },
+                    { id: 'S2', type: 'service', name: 'Item C Updated' },
+                ];
+                const overwriteResult = await dummy.msaveItem(overwriteItems);
+                expect2(() => overwriteResult.success.length).toEqual(2);
+                expect2(await dummy.readItem('S1'), 'ID,type,name').toEqual({
+                    ID: 'S1',
+                    type: 'service',
+                    name: 'Item B Updated',
+                });
+                expect2(await dummy.readItem('S2'), 'ID,type,name').toEqual({
+                    ID: 'S2',
+                    type: 'service',
+                    name: 'Item C Updated',
+                });
+
+                // 3. edge cases
+                //* empty string normalization
+                const emptyStringItems = [{ id: 'S4', type: '', name: 'Empty Type' }];
+                const emptyStringResult = await dummy.msaveItem(emptyStringItems);
+                expect2(() => emptyStringResult.success.length).toEqual(1);
+                expect2(await dummy.readItem('S4'), 'ID,type,name').toEqual({
+                    ID: 'S4',
+                    type: null,
+                    name: 'Empty Type',
+                });
+
+                //* large batch (> 25 items to test chunking)
+                const largeItems = Array.from({ length: 30 }, (_, i) => ({
+                    id: `T${i}`,
+                    type: 'batch',
+                    name: `Item ${i}`,
+                }));
+                const largeResult = await dummy.msaveItem(largeItems);
+                expect2(() => largeResult.total).toEqual(30);
+                expect2(() => largeResult.success.length).toEqual(30);
+                expect2(() => largeResult.failed.length).toEqual(0);
+
+                //* verify some items from large batch
+                expect2(await dummy.readItem('T0'), 'ID,type,name').toEqual({
+                    ID: 'T0',
+                    type: 'batch',
+                    name: 'Item 0',
+                });
+                expect2(await dummy.readItem('T25'), 'ID,type,name').toEqual({
+                    ID: 'T25',
+                    type: 'batch',
+                    name: 'Item 25',
+                });
+                expect2(await dummy.readItem('T29'), 'ID,type,name').toEqual({
+                    ID: 'T29',
+                    type: 'batch',
+                    name: 'Item 29',
+                });
+            }
+
+            //* mreadItem test
+            {
+                // 1. validate list parameter
+                //* null list
+                const nullResult = await dummy.mreadItem(null as any);
+                expect2(() => nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* undefined list
+                const undefinedResult = await dummy.mreadItem(undefined as any);
+                expect2(() => undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* empty list
+                const emptyResult = await dummy.mreadItem([]);
+                expect2(() => emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // 2. success cases
+                //* prepare test data first
+                await dummy.msaveItem([
+                    { id: 'R0', type: 'product', name: 'Read Item A' },
+                    { id: 'R1', type: 'product', name: 'Read Item B' },
+                    { id: 'R2', type: 'service', name: 'Read Item C' },
+                ]);
+
+                //* single item read
+                const singleRead = await dummy.mreadItem([{ id: 'R0' }]);
+                expect2(() => singleRead, 'total').toEqual({ total: 1 });
+                expect2(() => singleRead.success.length).toEqual(1);
+                expect2(() => singleRead.failed.length).toEqual(0);
+                expect2(() => singleRead.success[0], 'ID,type,name').toEqual({
+                    ID: 'R0',
+                    type: 'product',
+                    name: 'Read Item A',
+                });
+
+                //* multiple items read (small batch < 100)
+                const multipleRead = await dummy.mreadItem([{ id: 'R0' }, { id: 'R1' }, { id: 'R2' }]);
+                expect2(() => multipleRead, 'total').toEqual({ total: 3 });
+                expect2(() => multipleRead.success.length).toEqual(3);
+                expect2(() => multipleRead.failed.length).toEqual(0);
+
+                //* verify read items
+                const items = multipleRead.success;
+                expect2(() => items[0], 'ID,type,name').toEqual({ ID: 'R0', type: 'product', name: 'Read Item A' });
+                expect2(() => items[1], 'ID,type,name').toEqual({ ID: 'R1', type: 'product', name: 'Read Item B' });
+                expect2(() => items[2], 'ID,type,name').toEqual({ ID: 'R2', type: 'service', name: 'Read Item C' });
+
+                // 3. edge cases
+                //* read non-existent items (should fail)
+                const notFoundRead = await dummy.mreadItem([{ id: 'NOT_EXISTS' }]);
+                expect2(() => notFoundRead, 'total').toEqual({ total: 1 });
+                expect2(() => notFoundRead.success.length).toEqual(0);
+                expect2(() => notFoundRead.failed.length).toEqual(1);
+                expect2(() => notFoundRead.failed[0], 'ID').toEqual({ ID: 'NOT_EXISTS' });
+
+                //* mixed: some exist, some don't
+                const mixedRead = await dummy.mreadItem([{ id: 'R0' }, { id: 'NOT_EXISTS' }, { id: 'R1' }]);
+                expect2(() => mixedRead, 'total').toEqual({ total: 3 });
+                expect2(() => mixedRead.success.length).toEqual(2);
+                expect2(() => mixedRead.failed.length).toEqual(1);
+
+                //* large batch (> 100 items to test chunking)
+                const largeSaveItems = Array.from({ length: 110 }, (_, i) => ({
+                    id: `U${i}`,
+                    type: 'batch',
+                    name: `Item ${i}`,
+                }));
+                await dummy.msaveItem(largeSaveItems);
+
+                const largeReadKeys = Array.from({ length: 110 }, (_, i) => ({ id: `U${i}` }));
+                const largeRead = await dummy.mreadItem(largeReadKeys);
+                expect2(() => largeRead.total).toEqual(110);
+                expect2(() => largeRead.success.length).toEqual(110);
+                expect2(() => largeRead.failed.length).toEqual(0);
+
+                //* verify some items from large batch
+                const largeItems = largeRead.success;
+                const item0 = largeItems.find(item => item.ID === 'U0');
+                const item50 = largeItems.find(item => item.ID === 'U50');
+                const item109 = largeItems.find(item => item.ID === 'U109');
+                expect2(() => item0, 'ID,type,name').toEqual({ ID: 'U0', type: 'batch', name: 'Item 0' });
+                expect2(() => item50, 'ID,type,name').toEqual({ ID: 'U50', type: 'batch', name: 'Item 50' });
+                expect2(() => item109, 'ID,type,name').toEqual({ ID: 'U109', type: 'batch', name: 'Item 109' });
+            }
+
+            //* mupdateItem test
+            {
+                // 1. validate list parameter
+                // null list
+                const nullResult = await dummy.mupdateItem(null as any);
+                expect2(() => nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // undefined list
+                const undefinedResult = await dummy.mupdateItem(undefined as any);
+                expect2(() => undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // empty list
+                const emptyResult = await dummy.mupdateItem([]);
+                expect2(() => emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // 2. success cases
+                //* single item update
+                const singleItem = [{ id: 'B0', type: 'user', name: 'Alice' }];
+                const singleResult = await dummy.mupdateItem(singleItem);
+                expect2(() => singleResult, 'total').toEqual({ total: 1 });
+                expect2(() => singleResult.success.length).toEqual(1);
+                expect2(() => singleResult.failed.length).toEqual(0);
+                expect2(() => singleResult.success[0], 'ID,type,name').toEqual({
+                    ID: 'B0',
+                    type: 'user',
+                    name: 'Alice',
+                });
+
+                // verify saved item
+                expect2(await dummy.readItem('B0'), 'ID,type,name').toEqual({ ID: 'B0', type: 'user', name: 'Alice' });
+
+                //* multiple items update (small batch < 25)
+                const multipleItems = [
+                    { id: 'B1', type: 'user', name: 'Bob' },
+                    { id: 'B2', type: 'user', name: 'Charlie' },
+                    { id: 'B3', type: 'admin', name: 'David' },
+                ];
+                const multipleResult = await dummy.mupdateItem(multipleItems);
+                expect2(() => multipleResult, 'total').toEqual({ total: 3 });
+                expect2(() => multipleResult.success.length).toEqual(3);
+                expect2(() => multipleResult.failed.length).toEqual(0);
+
+                // verify all saved items
+                expect2(await dummy.readItem('B1'), 'ID,type,name').toEqual({ ID: 'B1', type: 'user', name: 'Bob' });
+                expect2(await dummy.readItem('B2'), 'ID,type,name').toEqual({
+                    ID: 'B2',
+                    type: 'user',
+                    name: 'Charlie',
+                });
+                expect2(await dummy.readItem('B3'), 'ID,type,name').toEqual({ ID: 'B3', type: 'admin', name: 'David' });
+
+                //* overwrite existing items
+                const overwriteItems = [
+                    { id: 'B1', type: 'admin', name: 'Bob Updated' },
+                    { id: 'B2', type: 'admin', name: 'Charlie Updated' },
+                ];
+                const overwriteResult = await dummy.mupdateItem(overwriteItems);
+                expect2(() => overwriteResult.success.length).toEqual(2);
+                expect2(await dummy.readItem('B1'), 'ID,type,name').toEqual({
+                    ID: 'B1',
+                    type: 'admin',
+                    name: 'Bob Updated',
+                });
+                expect2(await dummy.readItem('B2'), 'ID,type,name').toEqual({
+                    ID: 'B2',
+                    type: 'admin',
+                    name: 'Charlie Updated',
+                });
+
+                // 3. edge cases
+                //* empty string normalization
+                const emptyStringItems = [{ id: 'B4', type: '', name: 'Empty Type' }];
+                const emptyStringResult = await dummy.mupdateItem(emptyStringItems);
+                expect2(() => emptyStringResult.success.length).toEqual(1);
+                expect2(await dummy.readItem('B4'), 'ID,type,name').toEqual({
+                    ID: 'B4',
+                    type: null,
+                    name: 'Empty Type',
+                });
+
+                //* large batch (> 25 items to test chunking)
+                const largeItems = Array.from({ length: 30 }, (_, i) => ({
+                    id: `C${i}`,
+                    type: 'batch',
+                    name: `Item ${i}`,
+                }));
+                const largeResult = await dummy.mupdateItem(largeItems);
+                expect2(() => largeResult.total).toEqual(30);
+                expect2(() => largeResult.success.length).toEqual(30);
+                expect2(() => largeResult.failed.length).toEqual(0);
+
+                // verify some items from large batch
+                expect2(await dummy.readItem('C0'), 'ID,type,name').toEqual({ ID: 'C0', type: 'batch', name: 'Item 0' });
+                expect2(await dummy.readItem('C25'), 'ID,type,name').toEqual({
+                    ID: 'C25',
+                    type: 'batch',
+                    name: 'Item 25',
+                });
+                expect2(await dummy.readItem('C29'), 'ID,type,name').toEqual({
+                    ID: 'C29',
+                    type: 'batch',
+                    name: 'Item 29',
+                });
+            }
+
+            //* multiple crud operations (100+ items)
+            {
+                const count = 120;
+
+                //* msaveItem (100+ items)
+                const saveItems = Array.from({ length: count }, (_, i) => ({
+                    id: `ZD${i}`,
+                    type: 'dummy-multi',
+                    name: `Multi ${i}`,
+                }));
+                const saveResult = await dummy.msaveItem(saveItems);
+                expect2(() => saveResult.total).toEqual(count);
+                expect2(() => saveResult.success.length).toEqual(count);
+                expect2(() => saveResult.failed.length).toEqual(0);
+
+                //* mreadItem (100+ items)
+                const readKeys = saveItems.map(item => ({ id: item.id }));
+                const readResult = await dummy.mreadItem(readKeys);
+                expect2(() => readResult.total).toEqual(count);
+                expect2(() => readResult.success.length).toEqual(count);
+                expect2(() => readResult.failed.length).toEqual(0);
+                const readSample0 = readResult.success.find(item => item.ID === 'ZD0');
+                const readSample60 = readResult.success.find(item => item.ID === 'ZD60');
+                const readSample119 = readResult.success.find(item => item.ID === 'ZD119');
+                expect2(() => readSample0, 'ID,type,name').toEqual({
+                    ID: 'ZD0',
+                    type: 'dummy-multi',
+                    name: 'Multi 0',
+                });
+                expect2(() => readSample60, 'ID,type,name').toEqual({
+                    ID: 'ZD60',
+                    type: 'dummy-multi',
+                    name: 'Multi 60',
+                });
+                expect2(() => readSample119, 'ID,type,name').toEqual({
+                    ID: 'ZD119',
+                    type: 'dummy-multi',
+                    name: 'Multi 119',
+                });
+
+                //* mupdateItem (100+ items)
+                const updateItems = Array.from({ length: count }, (_, i) => ({
+                    id: `ZD${i}`,
+                    type: 'dummy-multi-updated',
+                    name: `Multi Updated ${i}`,
+                }));
+                const updateResult = await dummy.mupdateItem(updateItems);
+                expect2(() => updateResult.total).toEqual(count);
+                expect2(() => updateResult.success.length).toEqual(count);
+                expect2(() => updateResult.failed.length).toEqual(0);
+
+                //* verify updated items
+                expect2(await dummy.readItem('ZD0'), 'ID,type,name').toEqual({
+                    ID: 'ZD0',
+                    type: 'dummy-multi-updated',
+                    name: 'Multi Updated 0',
+                });
+                expect2(await dummy.readItem('ZD60'), 'ID,type,name').toEqual({
+                    ID: 'ZD60',
+                    type: 'dummy-multi-updated',
+                    name: 'Multi Updated 60',
+                });
+                expect2(await dummy.readItem('ZD119'), 'ID,type,name').toEqual({
+                    ID: 'ZD119',
+                    type: 'dummy-multi-updated',
+                    name: 'Multi Updated 119',
+                });
+            }
         });
     });
 
@@ -199,31 +576,471 @@ describe('DynamoService', () => {
             });
         });
 
-        it('should pass basic CRUD', async () => {
+        it('should pass mutiple crud operations with real DynamoDB', async () => {
             if (!PROFILE) return;
 
-            //* check dummy data.
-            expect2(service.hello()).toEqual(`dynamo-service:${tableName}`);
-            expect2(await service.readItem('00').catch(GETERR)).toEqual('404 NOT FOUND - ID:00');
-            expect2(await service.readItem('A0').catch(GETERR)).toEqual({ ID: 'A0', type: 'account', name: 'lemon' });
-            expect2(await service.readItem('A1').catch(GETERR), 'ID,type,name').toEqual({
-                ID: 'A1',
-                type: 'account',
-                name: 'Hong',
-            });
+            //* basic CRUD
+            {
+                //* check dummy data.
+                expect2(service.hello()).toEqual(`dynamo-service:${tableName}`);
+                expect2(await service.readItem('00').catch(GETERR)).toEqual('404 NOT FOUND - ID:00');
+                expect2(await service.readItem('A0').catch(GETERR)).toEqual({ ID: 'A0', type: 'account', name: 'lemon' });
+                expect2(await service.readItem('A1').catch(GETERR), 'ID,type,name').toEqual({
+                    ID: 'A1',
+                    type: 'account',
+                    name: 'Hong',
+                });
 
-            //* basic simple CRUD test.
-            expect2(await service.readItem('A0').catch(GETERR), 'ID').toEqual({ ID: 'A0' });
-            expect2(await service.deleteItem('A0').catch(GETERR)).toEqual(null);
-            expect2(await service.readItem('A0').catch(GETERR), 'ID').toEqual('404 NOT FOUND - ID:A0');
-            // empty string will be saved as null
-            expect2(await service.saveItem('A0', { type: '' }).catch(GETERR), 'ID,type').toEqual({
-                ID: 'A0',
-                type: null,
-            });
-            expect2(await service.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: null });
-            expect2(await service.updateItem('A0', 0, { type: 'account' }).catch(GETERR), 'ID').toEqual({ ID: 'A0' });
-            expect2(await service.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: 'account' });
+                //* basic simple CRUD test.
+                expect2(await service.readItem('A0').catch(GETERR), 'ID').toEqual({ ID: 'A0' });
+                expect2(await service.deleteItem('A0').catch(GETERR)).toEqual(null);
+                expect2(await service.readItem('A0').catch(GETERR), 'ID').toEqual('404 NOT FOUND - ID:A0');
+                // empty string will be saved as null
+                expect2(await service.saveItem('A0', { type: '' }).catch(GETERR), 'ID,type').toEqual({
+                    ID: 'A0',
+                    type: null,
+                });
+                expect2(await service.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: null });
+                expect2(await service.updateItem('A0', 0, { type: 'account' }).catch(GETERR), 'ID').toEqual({
+                    ID: 'A0',
+                });
+                expect2(await service.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: 'account' });
+            }
+
+            //* msaveItem test
+            {
+                // 1. validate list parameter
+                //* null list
+                const nullResult = await service.msaveItem(null as any);
+                expect2(() => nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* undefined list
+                const undefinedResult = await service.msaveItem(undefined as any);
+                expect2(() => undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* empty list
+                const emptyResult = await service.msaveItem([]);
+                expect2(() => emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // 2. success cases
+                //* single item save
+                const singleItem = [{ id: 'F0', type: 'real-product', name: 'Item A' }];
+                const singleResult = await service.msaveItem(singleItem);
+                dataMap.set('F0', singleItem[0] as MyModel);
+                expect2(() => singleResult, 'total').toEqual({ total: 1 });
+                expect2(() => singleResult.success.length).toEqual(1);
+                expect2(() => singleResult.failed.length).toEqual(0);
+                expect2(() => singleResult.success[0], 'ID,type,name').toEqual({
+                    ID: 'F0',
+                    type: 'real-product',
+                    name: 'Item A',
+                });
+
+                //* verify saved item
+                expect2(await service.readItem('F0'), 'ID,type,name').toEqual({
+                    ID: 'F0',
+                    type: 'real-product',
+                    name: 'Item A',
+                });
+
+                //* multiple items save (small batch < 25)
+                const multipleItems = [
+                    { id: 'F1', type: 'real-product', name: 'Item B' },
+                    { id: 'F2', type: 'real-product', name: 'Item C' },
+                    { id: 'F3', type: 'real-service', name: 'Item D' },
+                ];
+                const multipleResult = await service.msaveItem(multipleItems);
+                multipleItems.forEach(item => dataMap.set(item.id, item as MyModel));
+                expect2(() => multipleResult, 'total').toEqual({ total: 3 });
+                expect2(() => multipleResult.success.length).toEqual(3);
+                expect2(() => multipleResult.failed.length).toEqual(0);
+
+                //* verify all saved items
+                expect2(await service.readItem('F1'), 'ID,type,name').toEqual({
+                    ID: 'F1',
+                    type: 'real-product',
+                    name: 'Item B',
+                });
+                expect2(await service.readItem('F2'), 'ID,type,name').toEqual({
+                    ID: 'F2',
+                    type: 'real-product',
+                    name: 'Item C',
+                });
+                expect2(await service.readItem('F3'), 'ID,type,name').toEqual({
+                    ID: 'F3',
+                    type: 'real-service',
+                    name: 'Item D',
+                });
+
+                //* overwrite existing items
+                const overwriteItems = [
+                    { id: 'F1', type: 'real-service', name: 'Item B Updated' },
+                    { id: 'F2', type: 'real-service', name: 'Item C Updated' },
+                ];
+                const overwriteResult = await service.msaveItem(overwriteItems);
+                expect2(() => overwriteResult.success.length).toEqual(2);
+                expect2(await service.readItem('F1'), 'ID,type,name').toEqual({
+                    ID: 'F1',
+                    type: 'real-service',
+                    name: 'Item B Updated',
+                });
+                expect2(await service.readItem('F2'), 'ID,type,name').toEqual({
+                    ID: 'F2',
+                    type: 'real-service',
+                    name: 'Item C Updated',
+                });
+
+                // 3. edge cases
+                //* empty string normalization
+                const emptyStringItems = [{ id: 'F4', type: '', name: 'Empty Type' }];
+                const emptyStringResult = await service.msaveItem(emptyStringItems);
+                dataMap.set('F4', emptyStringItems[0] as MyModel);
+                expect2(() => emptyStringResult.success.length).toEqual(1);
+                expect2(await service.readItem('F4'), 'ID,type,name').toEqual({
+                    ID: 'F4',
+                    type: null,
+                    name: 'Empty Type',
+                });
+
+                //* large batch (> 25 items to test chunking)
+                const largeItems = Array.from({ length: 30 }, (_, i) => ({
+                    id: `G${i}`,
+                    type: 'real-batch',
+                    name: `Item ${i}`,
+                }));
+                const largeResult = await service.msaveItem(largeItems);
+                largeItems.forEach(item => dataMap.set(item.id, item as MyModel));
+                expect2(() => largeResult.total).toEqual(30);
+                expect2(() => largeResult.success.length).toEqual(30);
+                expect2(() => largeResult.failed.length).toEqual(0);
+
+                //* verify some items from large batch
+                expect2(await service.readItem('G0'), 'ID,type,name').toEqual({
+                    ID: 'G0',
+                    type: 'real-batch',
+                    name: 'Item 0',
+                });
+                expect2(await service.readItem('G25'), 'ID,type,name').toEqual({
+                    ID: 'G25',
+                    type: 'real-batch',
+                    name: 'Item 25',
+                });
+                expect2(await service.readItem('G29'), 'ID,type,name').toEqual({
+                    ID: 'G29',
+                    type: 'real-batch',
+                    name: 'Item 29',
+                });
+            }
+
+            //* mreadItem test
+            {
+                // 1. validate list parameter
+                //* null list
+                const nullResult = await service.mreadItem(null as any);
+                expect2(() => nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* undefined list
+                const undefinedResult = await service.mreadItem(undefined as any);
+                expect2(() => undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+                //* empty list
+                const emptyResult = await service.mreadItem([]);
+                expect2(() => emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // 2. success cases
+                //* prepare test data first
+                const prepareItems = [
+                    { id: 'H0', type: 'real-product', name: 'Read Item A' },
+                    { id: 'H1', type: 'real-product', name: 'Read Item B' },
+                    { id: 'H2', type: 'real-service', name: 'Read Item C' },
+                ];
+                await service.msaveItem(prepareItems);
+                prepareItems.forEach(item => dataMap.set(item.id, item as MyModel));
+
+                //* single item read
+                const singleRead = await service.mreadItem([{ id: 'H0' }]);
+                expect2(() => singleRead, 'total').toEqual({ total: 1 });
+                expect2(() => singleRead.success.length).toEqual(1);
+                expect2(() => singleRead.failed.length).toEqual(0);
+                expect2(() => singleRead.success[0], 'ID,type,name').toEqual({
+                    ID: 'H0',
+                    type: 'real-product',
+                    name: 'Read Item A',
+                });
+
+                //* multiple items read (small batch < 100)
+                const multipleRead = await service.mreadItem([{ id: 'H0' }, { id: 'H1' }, { id: 'H2' }]);
+                expect2(() => multipleRead, 'total').toEqual({ total: 3 });
+                expect2(() => multipleRead.success.length).toEqual(3);
+                expect2(() => multipleRead.failed.length).toEqual(0);
+
+                //* verify read items
+                const items = multipleRead.success;
+                const item0 = items.find(item => item.ID === 'H0');
+                const item1 = items.find(item => item.ID === 'H1');
+                const item2 = items.find(item => item.ID === 'H2');
+                expect2(() => item0, 'ID,type,name').toEqual({
+                    ID: 'H0',
+                    type: 'real-product',
+                    name: 'Read Item A',
+                });
+                expect2(() => item1, 'ID,type,name').toEqual({
+                    ID: 'H1',
+                    type: 'real-product',
+                    name: 'Read Item B',
+                });
+                expect2(() => item2, 'ID,type,name').toEqual({
+                    ID: 'H2',
+                    type: 'real-service',
+                    name: 'Read Item C',
+                });
+
+                // 3. edge cases
+                //* read non-existent items (should fail)
+                const notFoundRead = await service.mreadItem([{ id: 'NOT_EXISTS_REAL' }]);
+                expect2(() => notFoundRead, 'total').toEqual({ total: 1 });
+                expect2(() => notFoundRead.success.length).toEqual(0);
+                expect2(() => notFoundRead.failed.length).toEqual(1);
+                expect2(() => notFoundRead.failed[0], 'ID').toEqual({ ID: 'NOT_EXISTS_REAL' });
+
+                //* mixed: some exist, some don't
+                const mixedRead = await service.mreadItem([{ id: 'H0' }, { id: 'NOT_EXISTS_REAL2' }, { id: 'H1' }]);
+                expect2(() => mixedRead, 'total').toEqual({ total: 3 });
+                expect2(() => mixedRead.success.length).toEqual(2);
+                expect2(() => mixedRead.failed.length).toEqual(1);
+
+                //* large batch (> 100 items to test chunking)
+                const largeSaveItems = Array.from({ length: 110 }, (_, i) => ({
+                    id: `I${i}`,
+                    type: 'real-batch',
+                    name: `Item ${i}`,
+                }));
+                await service.msaveItem(largeSaveItems);
+                largeSaveItems.forEach(item => dataMap.set(item.id, item as MyModel));
+
+                const largeReadKeys = Array.from({ length: 110 }, (_, i) => ({ id: `I${i}` }));
+                const largeRead = await service.mreadItem(largeReadKeys);
+                expect2(() => largeRead.total).toEqual(110);
+                expect2(() => largeRead.success.length).toEqual(110);
+                expect2(() => largeRead.failed.length).toEqual(0);
+
+                //* verify some items from large batch
+                const largeItems = largeRead.success;
+                const largeItem0 = largeItems.find(item => item.ID === 'I0');
+                const largeItem50 = largeItems.find(item => item.ID === 'I50');
+                const largeItem109 = largeItems.find(item => item.ID === 'I109');
+                expect2(() => largeItem0, 'ID,type,name').toEqual({
+                    ID: 'I0',
+                    type: 'real-batch',
+                    name: 'Item 0',
+                });
+                expect2(() => largeItem50, 'ID,type,name').toEqual({
+                    ID: 'I50',
+                    type: 'real-batch',
+                    name: 'Item 50',
+                });
+                expect2(() => largeItem109, 'ID,type,name').toEqual({
+                    ID: 'I109',
+                    type: 'real-batch',
+                    name: 'Item 109',
+                });
+            }
+
+            //* mupdateItem test
+            {
+                // 1. validate list parameter
+                // null list
+                const nullResult = await service.mupdateItem(null as any);
+                expect2(() => nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // undefined list
+                const undefinedResult = await service.mupdateItem(undefined as any);
+                expect2(() => undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // empty list
+                const emptyResult = await service.mupdateItem([]);
+                expect2(() => emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+                // 2. success cases
+                //* single item update
+                const singleItem = [{ id: 'D0', type: 'real-user', name: 'Alice' }];
+                const singleResult = await service.mupdateItem(singleItem);
+                dataMap.set('D0', singleItem[0] as MyModel);
+                expect2(() => singleResult, 'total').toEqual({ total: 1 });
+                expect2(() => singleResult.success.length).toEqual(1);
+                expect2(() => singleResult.failed.length).toEqual(0);
+                expect2(() => singleResult.success[0], 'ID,type,name').toEqual({
+                    ID: 'D0',
+                    type: 'real-user',
+                    name: 'Alice',
+                });
+
+                // verify saved item
+                expect2(await service.readItem('D0'), 'ID,type,name').toEqual({
+                    ID: 'D0',
+                    type: 'real-user',
+                    name: 'Alice',
+                });
+
+                //* multiple items update (small batch < 25)
+                const multipleItems = [
+                    { id: 'D1', type: 'real-user', name: 'Bob' },
+                    { id: 'D2', type: 'real-user', name: 'Charlie' },
+                    { id: 'D3', type: 'real-admin', name: 'David' },
+                ];
+                const multipleResult = await service.mupdateItem(multipleItems);
+                multipleItems.forEach(item => dataMap.set(item.id, item as MyModel));
+                expect2(() => multipleResult, 'total').toEqual({ total: 3 });
+                expect2(() => multipleResult.success.length).toEqual(3);
+                expect2(() => multipleResult.failed.length).toEqual(0);
+
+                // verify all saved items
+                expect2(await service.readItem('D1'), 'ID,type,name').toEqual({
+                    ID: 'D1',
+                    type: 'real-user',
+                    name: 'Bob',
+                });
+                expect2(await service.readItem('D2'), 'ID,type,name').toEqual({
+                    ID: 'D2',
+                    type: 'real-user',
+                    name: 'Charlie',
+                });
+                expect2(await service.readItem('D3'), 'ID,type,name').toEqual({
+                    ID: 'D3',
+                    type: 'real-admin',
+                    name: 'David',
+                });
+
+                //* overwrite existing items
+                const overwriteItems = [
+                    { id: 'D1', type: 'real-admin', name: 'Bob Updated' },
+                    { id: 'D2', type: 'real-admin', name: 'Charlie Updated' },
+                ];
+                const overwriteResult = await service.mupdateItem(overwriteItems);
+                expect2(() => overwriteResult.success.length).toEqual(2);
+                expect2(await service.readItem('D1'), 'ID,type,name').toEqual({
+                    ID: 'D1',
+                    type: 'real-admin',
+                    name: 'Bob Updated',
+                });
+                expect2(await service.readItem('D2'), 'ID,type,name').toEqual({
+                    ID: 'D2',
+                    type: 'real-admin',
+                    name: 'Charlie Updated',
+                });
+
+                // 3. edge cases
+                //* empty string normalization
+                const emptyStringItems = [{ id: 'D4', type: '', name: 'Empty Type' }];
+                const emptyStringResult = await service.mupdateItem(emptyStringItems);
+                dataMap.set('D4', emptyStringItems[0] as MyModel);
+                expect2(() => emptyStringResult.success.length).toEqual(1);
+                expect2(await service.readItem('D4'), 'ID,type,name').toEqual({
+                    ID: 'D4',
+                    type: null,
+                    name: 'Empty Type',
+                });
+
+                //* large batch (> 25 items to test chunking)
+                const largeItems = Array.from({ length: 30 }, (_, i) => ({
+                    id: `E${i}`,
+                    type: 'real-batch',
+                    name: `Item ${i}`,
+                }));
+                const largeResult = await service.mupdateItem(largeItems);
+                largeItems.forEach(item => dataMap.set(item.id, item as MyModel));
+                expect2(() => largeResult.total).toEqual(30);
+                expect2(() => largeResult.success.length).toEqual(30);
+                expect2(() => largeResult.failed.length).toEqual(0);
+
+                // verify some items from large batch
+                expect2(await service.readItem('E0'), 'ID,type,name').toEqual({
+                    ID: 'E0',
+                    type: 'real-batch',
+                    name: 'Item 0',
+                });
+                expect2(await service.readItem('E25'), 'ID,type,name').toEqual({
+                    ID: 'E25',
+                    type: 'real-batch',
+                    name: 'Item 25',
+                });
+                expect2(await service.readItem('E29'), 'ID,type,name').toEqual({
+                    ID: 'E29',
+                    type: 'real-batch',
+                    name: 'Item 29',
+                });
+            }
+
+            //* multiple crud operations (100+ items)
+            {
+                const count = 120;
+
+                //* msaveItem (100+ items)
+                const saveItems = Array.from({ length: count }, (_, i) => ({
+                    id: `Z${i}`,
+                    type: 'real-multi',
+                    name: `Multi ${i}`,
+                }));
+                const saveResult = await service.msaveItem(saveItems);
+                saveItems.forEach(item => dataMap.set(item.id, item as MyModel));
+                expect2(() => saveResult.total).toEqual(count);
+                expect2(() => saveResult.success.length).toEqual(count);
+                expect2(() => saveResult.failed.length).toEqual(0);
+
+                //* mreadItem (100+ items)
+                const readKeys = saveItems.map(item => ({ id: item.id }));
+                const readResult = await service.mreadItem(readKeys);
+                expect2(() => readResult.total).toEqual(count);
+                expect2(() => readResult.success.length).toEqual(count);
+                expect2(() => readResult.failed.length).toEqual(0);
+                const readSample0 = readResult.success.find(item => item.ID === 'Z0');
+                const readSample60 = readResult.success.find(item => item.ID === 'Z60');
+                const readSample119 = readResult.success.find(item => item.ID === 'Z119');
+                expect2(() => readSample0, 'ID,type,name').toEqual({
+                    ID: 'Z0',
+                    type: 'real-multi',
+                    name: 'Multi 0',
+                });
+                expect2(() => readSample60, 'ID,type,name').toEqual({
+                    ID: 'Z60',
+                    type: 'real-multi',
+                    name: 'Multi 60',
+                });
+                expect2(() => readSample119, 'ID,type,name').toEqual({
+                    ID: 'Z119',
+                    type: 'real-multi',
+                    name: 'Multi 119',
+                });
+
+                //* mupdateItem (100+ items)
+                const updateItems = Array.from({ length: count }, (_, i) => ({
+                    id: `Z${i}`,
+                    type: 'real-multi-updated',
+                    name: `Multi Updated ${i}`,
+                }));
+                const updateResult = await service.mupdateItem(updateItems);
+                updateItems.forEach(item => dataMap.set(item.id, item as MyModel));
+                expect2(() => updateResult.total).toEqual(count);
+                expect2(() => updateResult.success.length).toEqual(count);
+                expect2(() => updateResult.failed.length).toEqual(0);
+
+                //* verify updated items
+                expect2(await service.readItem('Z0'), 'ID,type,name').toEqual({
+                    ID: 'Z0',
+                    type: 'real-multi-updated',
+                    name: 'Multi Updated 0',
+                });
+                expect2(await service.readItem('Z60'), 'ID,type,name').toEqual({
+                    ID: 'Z60',
+                    type: 'real-multi-updated',
+                    name: 'Multi Updated 60',
+                });
+                expect2(await service.readItem('Z119'), 'ID,type,name').toEqual({
+                    ID: 'Z119',
+                    type: 'real-multi-updated',
+                    name: 'Multi Updated 119',
+                });
+            }
         });
 
         afterAll(async () => {

--- a/src/cores/dynamo/dynamo-service.ts
+++ b/src/cores/dynamo/dynamo-service.ts
@@ -100,13 +100,22 @@ export class DynamoService<T extends GeneralItem> {
         const $cfg = awsConfig($engine, region);
         const dynamo = DynamoService._dynamo[region] ?? new DynamoDBClient($cfg); // Low-level DynamoDB client
         const dynamostr = DynamoService._dynamostr[region] ?? new DynamoDBStreamsClient($cfg); // DynamoDB Streams client
-        const dynamodoc =
-            DynamoService._dynamodoc[region] ??
-            (async (): Promise<DynamoDBDocumentClient> => {
-                const credentials = $cfg.credentials;
-                const dynamo = new DynamoDBClient({ ...$cfg, credentials }); // Low-level DynamoDB client
-                return DynamoDBDocumentClient.from(dynamo); // High-level Document client
-            });
+
+        // Create memoized function for dynamodoc
+        if (!DynamoService._dynamodoc[region]) {
+            const cache: { client: DynamoDBDocumentClient | null } = { client: null };
+            DynamoService._dynamodoc[region] = async (): Promise<DynamoDBDocumentClient> => {
+                if (!cache.client) {
+                    _log(NS, `! creating NEW DynamoDBDocumentClient for region[${region}]`);
+                    const credentials = $cfg.credentials;
+                    const dynamo = new DynamoDBClient({ ...$cfg, credentials });
+                    cache.client = DynamoDBDocumentClient.from(dynamo);
+                }
+                return cache.client;
+            };
+        }
+
+        const dynamodoc = DynamoService._dynamodoc[region]; // High-level Document client
         return { dynamo, dynamostr, dynamodoc };
     }
 

--- a/src/cores/dynamo/dynamo-service.ts
+++ b/src/cores/dynamo/dynamo-service.ts
@@ -450,6 +450,10 @@ export class DynamoService<T extends GeneralItem> {
             return `${id}${sortName ? '/' + sort : ''}`;
         };
 
+        //* Maps to preserve original order
+        const successMap = new Map<string, T>();
+        const failedMap = new Map<string, T>();
+
         //* process in chunks of 100 (DynamoDB BatchGetItem limit)
         const CHUNK_SIZE = 100;
 
@@ -493,17 +497,37 @@ export class DynamoService<T extends GeneralItem> {
 
             try {
                 const { items } = await _doBatchGet(chunkKeys, 1, []);
-                if (items.length > 0) result.success.push(...items);
+                items.forEach(item => {
+                    const sig = _convertItemToSig(item);
+                    successMap.set(sig, item);
+                });
 
                 const received = new Set(items.map(item => _convertItemToSig(item)));
                 const missing = Array.from(chunkKeyMap.entries())
                     .filter(([sig]) => !received.has(sig))
-                    .map(([, key]) => key as T);
-                if (missing.length > 0) result.failed.push(...missing);
+                    .map(([sig, key]) => {
+                        failedMap.set(sig, key as T);
+                        return key as T;
+                    });
             } catch (e) {
-                result.failed.push(...(Array.from(chunkKeyMap.values()) as T[]));
+                Array.from(chunkKeyMap.entries()).forEach(([sig, key]) => {
+                    failedMap.set(sig, key as T);
+                });
             }
         }
+
+        //* Preserve original order
+        list.forEach(item => {
+            const key = this.prepareItemKey(item.id, item.sort).Key as DynamoKey;
+            const sig = _convertKeyToSig(key);
+            const successItem = successMap.get(sig);
+            const failedItem = failedMap.get(sig);
+            if (successItem) {
+                result.success.push(successItem);
+            } else if (failedItem) {
+                result.failed.push(failedItem);
+            }
+        });
 
         _log(NS, `> mreadItem.res =`, {
             success: result.success.length,
@@ -693,7 +717,7 @@ export class DynamoService<T extends GeneralItem> {
      * @returns BatchResult with success/failed items
      */
     public async mupdateItem(list: Array<T & { id: string; sort?: string | number }>): Promise<BatchResult<T>> {
-        const { tableName } = this.options;
+        const { tableName, idName } = this.options;
         const total = list?.length ?? 0;
         const result: BatchResult<T> = { success: [], failed: [], total };
         if (!list || total === 0) return result;
@@ -701,18 +725,22 @@ export class DynamoService<T extends GeneralItem> {
         // _log(NS, `mupdateItem(${tableName})[${list.length}]...`);
         const dynamodoc = await DynamoService.instance().dynamodoc();
 
+        //* Maps to preserve original order
+        const successMap = new Map<string, T>();
+        const failedMap = new Map<string, T>();
+
         //* process in chunks of 25 (DynamoDB BatchWriteItem limit)
         const CHUNK_SIZE = 25;
 
         for (let i = 0; i < total; i += CHUNK_SIZE) {
             const chunk = list?.slice(i, i + CHUNK_SIZE) ?? [];
-            const chunkItems: T[] = [];
+            const chunkItemMap = new Map<string, T>();
 
             //* prepare batch write requests
             const putRequests = chunk.map(item => {
                 const { id, ...rest } = item;
                 const payload = this.prepareSaveItem(id, rest as unknown as T);
-                chunkItems.push(payload.Item as T);
+                chunkItemMap.set(id, payload.Item as T);
                 return {
                     PutRequest: {
                         Item: payload.Item,
@@ -751,16 +779,34 @@ export class DynamoService<T extends GeneralItem> {
                 const unprocessed = await _doBatchWrite(putRequests, 1);
                 if (unprocessed?.length > 0) {
                     //* partial failure: some items unprocessed after retries
-                    result.failed.push(...chunkItems);
+                    chunkItemMap.forEach((item, id) => {
+                        failedMap.set(id, item);
+                    });
                 } else {
                     //* all items in chunk succeeded
-                    result.success.push(...chunkItems);
+                    chunkItemMap.forEach((item, id) => {
+                        successMap.set(id, item);
+                    });
                 }
             } catch (e) {
                 //* chunk failed completely
-                result.failed.push(...chunkItems);
+                chunkItemMap.forEach((item, id) => {
+                    failedMap.set(id, item);
+                });
             }
         }
+
+        //* Preserve original order
+        list.forEach(item => {
+            const id = item.id;
+            const successItem = successMap.get(id);
+            const failedItem = failedMap.get(id);
+            if (successItem) {
+                result.success.push(successItem);
+            } else if (failedItem) {
+                result.failed.push(failedItem);
+            }
+        });
 
         _log(NS, `> mupdateItem.res =`, {
             success: result.success.length,

--- a/src/cores/dynamo/dynamo-service.ts
+++ b/src/cores/dynamo/dynamo-service.ts
@@ -16,12 +16,22 @@ import { GeneralItem, Incrementable } from 'lemon-model';
 import { awsConfig, loadDataYml } from '../../tools/';
 import { StreamViewType, KeySchemaElement } from '@aws-sdk/client-dynamodb';
 import { CreateTableCommand, DeleteTableCommand, DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, PutCommand, DeleteCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import {
+    DynamoDBDocumentClient,
+    GetCommand,
+    BatchGetCommand,
+    PutCommand,
+    DeleteCommand,
+    UpdateCommand,
+    BatchWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { DynamoDBStreamsClient } from '@aws-sdk/client-dynamodb-streams';
 
 const NS = $U.NS('DYNA', 'green'); // NAMESPACE TO BE PRINTED.
 
 export type KEY_TYPE = 'number' | 'string';
+type DynamoKey = Record<string, KEY_TYPE extends 'number' ? number : string>;
+type DynamoItem = Record<string, string | number | string[] | number[] | null>;
 
 export interface DynamoOption {
     tableName: string;
@@ -44,6 +54,26 @@ export interface DynamoOption {
  */
 export interface Updatable {
     [key: string]: GeneralItem['key'] | { setIndex: [number, string | number][] } | { removeIndex: number[] };
+}
+
+/**
+ * type: BatchWriteRequest for DynamoDB Document Client
+ */
+interface BatchWriteRequest {
+    PutRequest?: { Item: DynamoItem };
+    DeleteRequest?: { Key: DynamoKey };
+}
+
+/**
+ * type: BatchResult for batch operation results
+ */
+export interface BatchResult<T> {
+    /** successfully saved items */
+    success: T[];
+    /** failed items */
+    failed: T[];
+    /** total number of items */
+    total: number;
 }
 
 //* create(or get) instance.
@@ -395,6 +425,95 @@ export class DynamoService<T extends GeneralItem> {
     }
 
     /**
+     * multiple read-item
+     * - chunks requests into groups of 100 (DynamoDB BatchGetItem limit)
+     *
+     * @param list array of items with { id, sort? }
+     * @returns BatchResult with success/failed items
+     */
+    public async mreadItem(list: Array<{ id: string; sort?: string | number }>): Promise<BatchResult<T>> {
+        const { tableName, idName, sortName } = this.options;
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        const dynamodoc = await DynamoService.instance().dynamodoc();
+
+        const _convertKeyToSig = (key: DynamoKey) => {
+            const id = key[idName] as string | number;
+            const sort = sortName ? (key[sortName] as string | number) : undefined;
+            return `${id}${sortName ? '/' + sort : ''}`;
+        };
+        const _convertItemToSig = (item: T) => {
+            const id = item[idName] as string | number;
+            const sort = sortName ? (item[sortName] as string | number) : undefined;
+            return `${id}${sortName ? '/' + sort : ''}`;
+        };
+
+        //* process in chunks of 100 (DynamoDB BatchGetItem limit)
+        const CHUNK_SIZE = 100;
+
+        for (let i = 0; i < total; i += CHUNK_SIZE) {
+            const chunk = list?.slice(i, i + CHUNK_SIZE) ?? [];
+            const chunkKeyMap = new Map<string, DynamoKey>();
+
+            const chunkKeys = chunk.map(item => {
+                const key = this.prepareItemKey(item.id, item.sort).Key as DynamoKey;
+                const sig = _convertKeyToSig(key);
+                if (!chunkKeyMap.has(sig)) chunkKeyMap.set(sig, key);
+                return key;
+            });
+
+            const MAX_RETRIES = 3;
+            const _doBatchGet = async (
+                keys: DynamoKey[],
+                attempt: number,
+                acc: T[],
+            ): Promise<{ items: T[]; unprocessed: DynamoKey[] }> => {
+                const response = await dynamodoc
+                    .send(new BatchGetCommand({ RequestItems: { [tableName]: { Keys: keys } } }))
+                    .catch((e: Error) => {
+                        if (`${e.message}`.includes('ResourceNotFoundException'))
+                            throw new Error(`404 NOT FOUND - table:${tableName}`);
+                        throw e;
+                    });
+
+                const items = (response.Responses?.[tableName] ?? []) as T[];
+                if (items.length > 0) acc.push(...items);
+
+                const unprocessed = (response.UnprocessedKeys?.[tableName]?.Keys ?? []) as DynamoKey[];
+                if (unprocessed.length > 0) {
+                    if (attempt >= MAX_RETRIES) return { items: acc, unprocessed };
+                    //* exponential backoff
+                    await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 100));
+                    return _doBatchGet(unprocessed, attempt + 1, acc);
+                }
+                return { items: acc, unprocessed: [] };
+            };
+
+            try {
+                const { items } = await _doBatchGet(chunkKeys, 1, []);
+                if (items.length > 0) result.success.push(...items);
+
+                const received = new Set(items.map(item => _convertItemToSig(item)));
+                const missing = Array.from(chunkKeyMap.entries())
+                    .filter(([sig]) => !received.has(sig))
+                    .map(([, key]) => key as T);
+                if (missing.length > 0) result.failed.push(...missing);
+            } catch (e) {
+                result.failed.push(...(Array.from(chunkKeyMap.values()) as T[]));
+            }
+        }
+
+        _log(NS, `> mreadItem.res =`, {
+            success: result.success.length,
+            failed: result.failed.length,
+            total: result.total,
+        });
+        return result;
+    }
+
+    /**
      * save-item
      * - save whole data with param (use update if partial save)
      *
@@ -420,6 +539,92 @@ export class DynamoService<T extends GeneralItem> {
                     throw new Error(`404 NOT FOUND - ${idName}:${id}`);
                 throw e;
             });
+    }
+
+    /**
+     * multiple save-item
+     * - chunks requests into groups of 25 (DynamoDB BatchWriteItem limit)
+     * - NOTE: This overwrites entire items (no partial update or increment support)
+     *
+     * @param list array of items with { id, sort?, ...model }
+     * @returns BatchResult with success/failed items
+     */
+    public async msaveItem(list: Array<T & { id: string; sort?: string | number }>): Promise<BatchResult<T>> {
+        const { tableName } = this.options;
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        // _log(NS, `msaveItem(${tableName})[${list.length}]...`);
+        const dynamodoc = await DynamoService.instance().dynamodoc();
+
+        //* process in chunks of 25 (DynamoDB BatchWriteItem limit)
+        const CHUNK_SIZE = 25;
+
+        for (let i = 0; i < total; i += CHUNK_SIZE) {
+            const chunk = list?.slice(i, i + CHUNK_SIZE) ?? [];
+            const chunkItems: T[] = [];
+
+            //* prepare batch write requests
+            const putRequests: BatchWriteRequest[] = chunk.map(item => {
+                const { id, ...rest } = item;
+                const payload = this.prepareSaveItem(id, rest as T);
+                chunkItems.push(payload.Item);
+                return {
+                    PutRequest: {
+                        Item: payload.Item,
+                    },
+                };
+            });
+
+            //* execute batch write with retry for unprocessed items
+            const MAX_RETRIES = 3;
+            const _doBatchWrite = async (
+                requests: BatchWriteRequest[],
+                attempt: number,
+            ): Promise<BatchWriteRequest[]> => {
+                const response = await dynamodoc
+                    .send(new BatchWriteCommand({ RequestItems: { [tableName]: requests } }))
+                    .catch((e: Error) => {
+                        if (`${e.message}`.includes('ResourceNotFoundException'))
+                            throw new Error(`404 NOT FOUND - table:${tableName}`);
+                        throw e;
+                    });
+
+                //* check for unprocessed items
+                const unprocessed = response.UnprocessedItems?.[tableName];
+                if (unprocessed && unprocessed?.length > 0) {
+                    if (attempt >= MAX_RETRIES) {
+                        return unprocessed;
+                    }
+                    //* exponential backoff
+                    await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 100));
+                    return _doBatchWrite(unprocessed, attempt + 1);
+                }
+                return [];
+            };
+
+            try {
+                const unprocessed = await _doBatchWrite(putRequests, 1);
+                if (unprocessed?.length > 0) {
+                    //* partial failure: some items unprocessed after retries
+                    result.failed.push(...chunkItems);
+                } else {
+                    //* all items in chunk succeeded
+                    result.success.push(...chunkItems);
+                }
+            } catch (e) {
+                //* chunk failed completely
+                result.failed.push(...chunkItems);
+            }
+        }
+
+        _log(NS, `> msaveItem.res =`, {
+            success: result.success.length,
+            failed: result.failed.length,
+            total: result.total,
+        });
+        return result;
     }
 
     /**
@@ -478,6 +683,92 @@ export class DynamoService<T extends GeneralItem> {
                 throw e;
             });
     }
+
+    /**
+     * multiple update-item
+     * - chunks requests into groups of 25 (DynamoDB BatchWriteItem limit)
+     * - NOTE: This overwrites entire items (no partial update or increment support)
+     *
+     * @param list array of items with { id, sort?, ...model }
+     * @returns BatchResult with success/failed items
+     */
+    public async mupdateItem(list: Array<T & { id: string; sort?: string | number }>): Promise<BatchResult<T>> {
+        const { tableName } = this.options;
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        // _log(NS, `mupdateItem(${tableName})[${list.length}]...`);
+        const dynamodoc = await DynamoService.instance().dynamodoc();
+
+        //* process in chunks of 25 (DynamoDB BatchWriteItem limit)
+        const CHUNK_SIZE = 25;
+
+        for (let i = 0; i < total; i += CHUNK_SIZE) {
+            const chunk = list?.slice(i, i + CHUNK_SIZE) ?? [];
+            const chunkItems: T[] = [];
+
+            //* prepare batch write requests
+            const putRequests = chunk.map(item => {
+                const { id, ...rest } = item;
+                const payload = this.prepareSaveItem(id, rest as unknown as T);
+                chunkItems.push(payload.Item as T);
+                return {
+                    PutRequest: {
+                        Item: payload.Item,
+                    },
+                };
+            });
+
+            //* execute batch write with retry for unprocessed items
+            const MAX_RETRIES = 3;
+            const _doBatchWrite = async (
+                requests: BatchWriteRequest[],
+                attempt: number,
+            ): Promise<BatchWriteRequest[]> => {
+                const response = await dynamodoc
+                    .send(new BatchWriteCommand({ RequestItems: { [tableName]: requests } }))
+                    .catch((e: Error) => {
+                        if (`${e.message}`.includes('ResourceNotFoundException'))
+                            throw new Error(`404 NOT FOUND - table:${tableName}`);
+                        throw e;
+                    });
+
+                //* check for unprocessed items
+                const unprocessed = response.UnprocessedItems?.[tableName];
+                if (unprocessed && unprocessed?.length > 0) {
+                    if (attempt >= MAX_RETRIES) {
+                        return unprocessed;
+                    }
+                    //* exponential backoff
+                    await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 100));
+                    return _doBatchWrite(unprocessed, attempt + 1);
+                }
+                return [];
+            };
+
+            try {
+                const unprocessed = await _doBatchWrite(putRequests, 1);
+                if (unprocessed?.length > 0) {
+                    //* partial failure: some items unprocessed after retries
+                    result.failed.push(...chunkItems);
+                } else {
+                    //* all items in chunk succeeded
+                    result.success.push(...chunkItems);
+                }
+            } catch (e) {
+                //* chunk failed completely
+                result.failed.push(...chunkItems);
+            }
+        }
+
+        _log(NS, `> mupdateItem.res =`, {
+            success: result.success.length,
+            failed: result.failed.length,
+            total: result.total,
+        });
+        return result;
+    }
 }
 
 /** ****************************************************************************************************************
@@ -534,10 +825,58 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
         return { [idName]: id, ...item };
     }
 
+    public async mreadItem(list: Array<{ id: string; sort?: string | number }>): Promise<BatchResult<T>> {
+        const { idName, sortName } = this.options;
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        for (const item of list) {
+            const data: T = this.buffer[item.id];
+            if (data === undefined) {
+                const key = sortName
+                    ? ({ [idName]: item.id, [sortName]: item.sort } as T)
+                    : ({ [idName]: item.id } as T);
+                result.failed.push(key);
+                continue;
+            }
+            result.success.push({ [idName]: item.id, ...data } as T);
+        }
+
+        _log(NS, `> mreadItem.res =`, {
+            success: result.success.length,
+            failed: result.failed.length,
+            total: result.total,
+        });
+        return result;
+    }
+
     public async saveItem(id: string, item: T): Promise<T> {
         const { idName } = this.options;
         this.buffer[id] = normalize(item);
         return { [idName]: id, ...this.buffer[id] };
+    }
+
+    public async msaveItem(list: Array<T & { id: string; sort?: string | number }>): Promise<BatchResult<T>> {
+        const { idName } = this.options;
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        // _log(NS, `msaveItem(dummy)[${list.length}]...`);
+        //* process all saves using the in-memory buffer (overwrites entire items)
+        for (const item of list) {
+            const { id, ...rest } = item;
+            this.buffer[id] = normalize(rest as T);
+            result.success.push({ [idName]: id, ...this.buffer[id] } as T);
+        }
+
+        _log(NS, `> msaveItem.res =`, {
+            success: result.success.length,
+            failed: result.failed.length,
+            total: result.total,
+        });
+        return result;
     }
 
     public async deleteItem(id: string, sort?: string | number): Promise<T> {
@@ -551,5 +890,28 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
         if (item === undefined) throw new Error(`404 NOT FOUND - ${idName}:${id}`);
         this.buffer[id] = { ...item, ...normalize(updates) };
         return { [idName]: id, ...this.buffer[id] };
+    }
+
+    public async mupdateItem(list: Array<T & { id: string; sort?: string | number }>): Promise<BatchResult<T>> {
+        const { idName } = this.options;
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        // _log(NS, `mupdateItem(dummy)[${list.length}]...`);
+        //* process all updates using the in-memory buffer (overwrites entire items)
+        for (const item of list) {
+            const { id, ...rest } = item;
+            //* overwrite entire item (same as PutItem behavior)
+            this.buffer[id] = normalize(rest as any);
+            result.success.push({ [idName]: id, ...this.buffer[id] } as any);
+        }
+
+        _log(NS, `> mupdateItem.res =`, {
+            success: result.success.length,
+            failed: result.failed.length,
+            total: result.total,
+        });
+        return result;
     }
 }

--- a/src/cores/storage/proxy-storage-service.spec.ts
+++ b/src/cores/storage/proxy-storage-service.spec.ts
@@ -51,7 +51,7 @@ class MyModelFilter extends GeneralModelFilter<MyModel, MyType> {
         return model;
     }
     public beforeUpdate(model: MyModel, incrementals?: MyModel): MyModel {
-        if (model.price) incrementals.count = 1; // increment count so.
+        if (model.price && incrementals) incrementals.count = 1; // increment count so.
         return model;
     }
 }
@@ -551,6 +551,228 @@ describe('ProxyStorageService', () => {
         expect2(() => data3.pop()).toEqual({});
         expect2(() => Object.keys(data3)).toEqual([]);
         expect2(() => data3.pop()).toEqual('data3.pop is not a function');
+    });
+
+    //* test doReadMulti
+    it('should pass doReadMulti()', async () => {
+        const { storage, current } = instance('dummy-account-data.yml');
+        const $test = storage.makeTypedStorageService('test');
+
+        const createdAt = current + 10;
+        const updatedAt = current + 100;
+
+        //* 1. validate parameters test
+        // null ids
+        expect2(await storage.doReadMulti('test', null as any)).toEqual({
+            success: [],
+            failed: [],
+            total: 0,
+        });
+
+        // empty array
+        expect2(await storage.doReadMulti('test', [])).toEqual({
+            success: [],
+            failed: [],
+            total: 0,
+        });
+
+        // undefined ids
+        expect2(await storage.doReadMulti('test', undefined as any)).toEqual({
+            success: [],
+            failed: [],
+            total: 0,
+        });
+
+        //* 2. match err cases
+        // prepare test data first
+        await $test.delete('multi-read-1').catch(GETERR);
+        await $test.delete('multi-read-2').catch(GETERR);
+        await $test.delete('multi-read-3').catch(GETERR);
+
+        await $test.save('multi-read-1', { name: 'Item 1' });
+        await $test.save('multi-read-2', { name: 'Item 2' });
+
+        // non-existent IDs only
+        const notFoundResult = await storage.doReadMulti('test', ['non-exist-1', 'non-exist-2']);
+        expect2(() => notFoundResult.total).toEqual(2);
+        expect2(() => notFoundResult.success.length).toEqual(0);
+        expect2(() => notFoundResult.failed.length).toEqual(2);
+
+        // mixed existing and non-existing IDs
+        const mixedResult = await storage.doReadMulti('test', ['multi-read-1', 'non-exist', 'multi-read-2']);
+        expect2(() => mixedResult.total).toEqual(3);
+        expect2(() => mixedResult.success.length).toEqual(2);
+        expect2(() => mixedResult.failed.length).toEqual(1);
+
+        //* 3. success cases
+        // read single model
+        const singleResult = await storage.doReadMulti('test', ['multi-read-1']);
+        expect2(() => singleResult.total).toEqual(1);
+        expect2(() => singleResult.success.length).toEqual(1);
+        expect2(() => singleResult.failed.length).toEqual(0);
+        expect2(() => singleResult.success[0], 'id,name').toEqual({
+            id: 'multi-read-1',
+            name: 'Item 1',
+        });
+
+        // read multiple models
+        await $test.save('multi-read-3', { name: 'Item 3' });
+        const multiResult = await storage.doReadMulti('test', ['multi-read-1', 'multi-read-2', 'multi-read-3']);
+        expect2(() => multiResult.total).toEqual(3);
+        expect2(() => multiResult.success.length).toEqual(3);
+        expect2(() => multiResult.failed.length).toEqual(0);
+
+        // verify BatchResult structure
+        expect2(() => typeof multiResult.total).toEqual('number');
+        expect2(() => Array.isArray(multiResult.success)).toEqual(true);
+        expect2(() => Array.isArray(multiResult.failed)).toEqual(true);
+
+        // verify afterRead filter is applied and _id is properly set
+        multiResult.success.forEach((model, index) => {
+            const expectedId = `multi-read-${index + 1}`;
+            expect2(() => model, '_id,id,name').toEqual({
+                _id: `TT:test:${expectedId}`,
+                id: expectedId,
+                name: `Item ${index + 1}`,
+            });
+        });
+
+        //* cleanup
+        await $test.delete('multi-read-1').catch(GETERR);
+        await $test.delete('multi-read-2').catch(GETERR);
+        await $test.delete('multi-read-3').catch(GETERR);
+    });
+
+    //* test doUpdateMulti
+    it('should pass doUpdateMulti()', async () => {
+        const { storage, current } = instance('dummy-account-data.yml');
+        const $test = storage.makeTypedStorageService('test');
+
+        //* doUpdateMulti test
+
+        const createdAt = current + 10;
+        const updatedAt = current + 100;
+
+        //* 1. validate parameters test
+        // null list
+        expect2(await storage.doUpdateMulti('test', null as any)).toEqual({
+            success: [],
+            failed: [],
+            total: 0,
+        });
+
+        // empty array
+        expect2(await storage.doUpdateMulti('test', [])).toEqual({
+            success: [],
+            failed: [],
+            total: 0,
+        });
+
+        // undefined list
+        expect2(await storage.doUpdateMulti('test', undefined as any)).toEqual({
+            success: [],
+            failed: [],
+            total: 0,
+        });
+
+        // missing id in item
+        expect2(await storage.doUpdateMulti('test', [{ name: 'no id' } as any]).catch(GETERR)).toEqual(
+            '@id is required!',
+        );
+
+        //* 2. match err cases
+        // prepare test data
+        await $test.delete('multi-update-1').catch(GETERR);
+        await $test.delete('multi-update-2').catch(GETERR);
+        await $test.delete('multi-update-3').catch(GETERR);
+
+        await $test.save('multi-update-1', { name: 'Original 1' });
+        await $test.save('multi-update-2', { name: 'Original 2' });
+
+        // update existing items
+        const updateResult = await storage.doUpdateMulti('test', [
+            { id: 'multi-update-1', name: 'Updated 1' },
+            { id: 'multi-update-2', name: 'Updated 2' },
+        ]);
+
+        expect2(() => updateResult.total).toEqual(2);
+        expect2(() => updateResult.success.length).toEqual(2);
+        expect2(() => updateResult.failed.length).toEqual(0);
+
+        //* 3. success cases
+        // update single item
+        const singleUpdateResult = await storage.doUpdateMulti('test', [
+            { id: 'multi-update-1', name: 'Single Update' },
+        ]);
+        expect2(() => singleUpdateResult.total).toEqual(1);
+        expect2(() => singleUpdateResult.success.length).toEqual(1);
+        expect2(() => singleUpdateResult.failed.length).toEqual(0);
+        expect2(() => singleUpdateResult.success[0], 'name,updatedAt').toEqual({
+            name: 'Single Update',
+            updatedAt,
+        });
+
+        // update multiple items
+        const multiUpdateResult = await storage.doUpdateMulti('test', [
+            { id: 'multi-update-1', name: 'Multi Update 1' },
+            { id: 'multi-update-2', name: 'Multi Update 2' },
+            { id: 'multi-update-3', name: 'Multi Update 3' },
+        ]);
+        expect2(() => multiUpdateResult.total).toEqual(3);
+        expect2(() => multiUpdateResult.success.length).toEqual(3);
+        expect2(() => multiUpdateResult.failed.length).toEqual(0);
+
+        // verify BatchResult structure
+        expect2(() => typeof multiUpdateResult.total).toEqual('number');
+        expect2(() => Array.isArray(multiUpdateResult.success)).toEqual(true);
+        expect2(() => Array.isArray(multiUpdateResult.failed)).toEqual(true);
+
+        // verify afterUpdate filter is applied
+        multiUpdateResult.success.forEach((model, index) => {
+            const expectedId = `multi-update-${index + 1}`;
+            expect2(() => model, '_id,name').toEqual({
+                _id: `TT:test:${expectedId}`,
+                name: `Multi Update ${index + 1}`,
+            });
+        });
+
+        // verify updatedAt is set correctly
+        multiUpdateResult.success.forEach(model => {
+            expect2(() => model.updatedAt).toEqual(updatedAt);
+        });
+
+        // verify auto-creation on update
+        await $test.delete('auto-create-1').catch(GETERR);
+        const autoCreateResult = await storage.doUpdateMulti('test', [{ id: 'auto-create-1', name: 'Auto Created' }]);
+        expect2(() => autoCreateResult.success.length).toEqual(1);
+        const retrieved = await $test.read('auto-create-1');
+        expect2(() => retrieved, 'name').toEqual({ name: 'Auto Created' });
+
+        // verify _id is removed and updatedAt is added
+        await $test.delete('filter-test').catch(GETERR);
+        await $test.save('filter-test', { name: 'Filter Test' });
+
+        const filterResult = await storage.doUpdateMulti('test', [
+            { id: 'filter-test', name: 'Updated Name', _id: 'should-be-removed' as any },
+        ]);
+        // _id should be removed from update and updatedAt should be set
+        expect2(() => filterResult.success[0], 'name,updatedAt').toEqual({
+            name: 'Updated Name',
+            updatedAt,
+        });
+
+        const filterRetrieved = await $test.read('filter-test');
+        expect2(() => filterRetrieved, 'name,updatedAt').toEqual({
+            name: 'Updated Name',
+            updatedAt,
+        });
+
+        //* cleanup
+        await $test.delete('multi-update-1').catch(GETERR);
+        await $test.delete('multi-update-2').catch(GETERR);
+        await $test.delete('multi-update-3').catch(GETERR);
+        await $test.delete('auto-create-1').catch(GETERR);
+        await $test.delete('filter-test').catch(GETERR);
     });
 
     //* dummy storage service.

--- a/src/cores/storage/proxy-storage-service.ts
+++ b/src/cores/storage/proxy-storage-service.ts
@@ -14,6 +14,7 @@ import { Elastic6SimpleQueriable, CoreModel, CORE_FIELDS } from 'lemon-model';
 import { NUL404 } from '../../common/test-helper';
 import { StorageService, DummyStorageService, DynamoStorageService } from './storage-service';
 import { GeneralAPIController } from '../../controllers/general-api-controller';
+import { BatchResult } from '../dynamo/dynamo-service';
 const NS = $U.NS('PSTR', 'blue'); // NAMESPACE TO BE PRINTED.
 
 /**
@@ -495,6 +496,31 @@ export class ProxyStorageService<T extends CoreModel<ModelType>, ModelType exten
     }
 
     /**
+     * read multiple models by key + ids
+     *
+     * @param type      model-type
+     * @param ids       node-ids
+     */
+    public async doReadMulti(type: ModelType, ids: string[]): Promise<BatchResult<T>> {
+        const total = ids?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!ids || total === 0) return result;
+
+        const _ids = ids.map(id => this.asKey(type, id));
+        const res = await (this.storage as any).mread(_ids);
+
+        result.success = (res.success || []).map((model: T) => {
+            const res = this.filters.afterRead(model);
+            return res;
+        });
+        result.failed = (res.failed || []).map((model: T) => {
+            const res = this.filters.afterRead(model);
+            return res;
+        });
+        return result;
+    }
+
+    /**
      * delete model by id.
      *
      * @param type      model-type
@@ -530,6 +556,40 @@ export class ProxyStorageService<T extends CoreModel<ModelType>, ModelType exten
         //* make sure it has `_id`
         (model as any)[this.idName] = _id;
         return this.filters.afterUpdate(model);
+    }
+
+    /**
+     * update multiple models (or it will create automatically)
+     *
+     * @param type      model-type
+     * @param list      list of models (should include id)
+     */
+    public async doUpdateMulti(type: ModelType, list: Array<T & { id: string }>): Promise<BatchResult<T>> {
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        const { updatedAt } = this.asTime();
+        const items = list.map((node: T & { id: string }) => {
+            const id = node.id;
+            if (!id) throw new Error('@id is required!');
+            const _id = this.asKey(type, id);
+            const node2 = this.filters.beforeUpdate({ ...node, [this.idName]: _id }, undefined);
+            delete node2['_id'];
+            return { ...node2, [this.idName]: _id, updatedAt };
+        });
+
+        const res = await (this.storage as any).mupdate(items);
+
+        result.success = (res.success || []).map((model: T) => {
+            const res = this.filters.afterUpdate(model);
+            return res;
+        });
+        result.failed = (res.failed || []).map((model: T) => {
+            const res = this.filters.afterUpdate(model);
+            return res;
+        });
+        return result;
     }
 
     /**

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -23,6 +23,160 @@ describe('StorageService', () => {
     const PROFILE = loadProfile(process); // override process.env.
     if (PROFILE) console.info(`! PROFILE =`, PROFILE);
 
+    // Track test data for cleanup
+    const testDataIds = new Set<string>();
+
+    //* dummy storage service - mread tests
+    it('should pass dummy storage-service mread operations', async () => {
+        //* load dummy storage service
+        const $storage = new DummyStorageService('ticketing-dummy-data', 'memory', 'id');
+        const $account = $storage as DummyStorageService<AccountModel>;
+
+        //* mread test
+        // 1. validate ids parameter test
+        // - null ids
+        const nullResult = await $account.mread(null as any);
+        expect2(nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - undefined ids
+        const undefinedResult = await $account.mread(undefined as any);
+        expect2(undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - empty array
+        const emptyResult = await $account.mread([]);
+        expect2(emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // 2. match error cases
+        // - invalid id (empty string) in array
+        expect2(await $account.mread(['', 'A00000']).catch(GETERR)).toEqual('@id (string) is required!');
+
+        // - invalid id (whitespace only) in array
+        expect2(await $account.mread(['  ', 'A00000']).catch(GETERR)).toEqual('@id (string) is required!');
+
+        // 3. success cases
+        // - setup test data
+        await $account.save('M00001', { type: 'account', name: 'user1', balance: 100 });
+        await $account.save('M00002', { type: 'account', name: 'user2', balance: 200 });
+        await $account.save('M00003', { type: 'account', name: 'user3', balance: 300 });
+
+        // - read single existing id
+        const single = await $account.mread(['M00001']);
+        expect2(single.total).toEqual(1);
+        expect2(single.success.length).toEqual(1);
+        expect2(single.failed.length).toEqual(0);
+        expect2(() => single.success[0], 'id,name,balance').toEqual({ id: 'M00001', name: 'user1', balance: 100 });
+
+        // - read multiple existing ids
+        const multiple = await $account.mread(['M00001', 'M00002', 'M00003']);
+        expect2(multiple.total).toEqual(3);
+        expect2(multiple.success.length).toEqual(3);
+        expect2(multiple.failed.length).toEqual(0);
+        expect2(() => multiple.success[0], 'id,name').toEqual({ id: 'M00001', name: 'user1' });
+        expect2(() => multiple.success[1], 'id,name').toEqual({ id: 'M00002', name: 'user2' });
+        expect2(() => multiple.success[2], 'id,name').toEqual({ id: 'M00003', name: 'user3' });
+
+        // - read mixed (existing and non-existing ids)
+        const mixed = await $account.mread(['M00001', 'NOTFOUND1', 'M00002', 'NOTFOUND2']);
+        expect2(mixed.total).toEqual(4);
+        expect2(mixed.success.length).toEqual(2);
+        expect2(mixed.failed.length).toEqual(2);
+        expect2(() => mixed.success[0], 'id,name').toEqual({ id: 'M00001', name: 'user1' });
+        expect2(() => mixed.success[1], 'id,name').toEqual({ id: 'M00002', name: 'user2' });
+        expect2(() => mixed.failed[0], 'id').toEqual({ id: 'NOTFOUND1' });
+        expect2(() => mixed.failed[1], 'id').toEqual({ id: 'NOTFOUND2' });
+
+        // - read all non-existing ids
+        const allFailed = await $account.mread(['NOTFOUND1', 'NOTFOUND2', 'NOTFOUND3']);
+        expect2(allFailed.total).toEqual(3);
+        expect2(allFailed.success.length).toEqual(0);
+        expect2(allFailed.failed.length).toEqual(3);
+
+        // - cleanup
+        await $account.delete('M00001');
+        await $account.delete('M00002');
+        await $account.delete('M00003');
+    });
+
+    //* dummy storage service - mupdate tests
+    it('should pass dummy storage-service mupdate operations', async () => {
+        //* load dummy storage service
+        const $storage = new DummyStorageService('ticketing-dummy-data', 'memory', 'id');
+        const $account = $storage as DummyStorageService<AccountModel>;
+
+        //* mupdate test
+        // 1. validate list parameter test
+        // - null list
+        const nullResult = await $account.mupdate(null as any);
+        expect2(nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - undefined list
+        const undefinedResult = await $account.mupdate(undefined as any);
+        expect2(undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - empty array
+        const emptyResult = await $account.mupdate([]);
+        expect2(emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // 2. match error cases
+        // - missing id in item
+        expect2(await $account.mupdate([{ type: 'account', name: 'test' } as any]).catch(GETERR)).toEqual(
+            '@id is required!',
+        );
+
+        // - item without id field
+        expect2(
+            await $account.mupdate([{ type: 'account', balance: 100 }, { type: 'account' }] as any).catch(GETERR),
+        ).toEqual('@id is required!');
+
+        // 3. success cases
+        // - update single item (create new)
+        const single = await $account.mupdate([{ id: 'U00001', type: 'account', name: 'test1', balance: 100 }]);
+        expect2(single.total).toEqual(1);
+        expect2(single.success.length).toEqual(1);
+        expect2(single.failed.length).toEqual(0);
+        expect2(() => single.success[0], 'id,name,balance').toEqual({ id: 'U00001', name: 'test1', balance: 100 });
+
+        // - verify saved
+        const verified1 = await $account.read('U00001');
+        expect2(() => verified1, 'id,name,balance').toEqual({ id: 'U00001', name: 'test1', balance: 100 });
+
+        // - update multiple items
+        const multiple = await $account.mupdate([
+            { id: 'U00002', type: 'account', name: 'test2', balance: 200 },
+            { id: 'U00003', type: 'account', name: 'test3', balance: 300 },
+            { id: 'U00004', type: 'account', name: 'test4', balance: 400 },
+        ]);
+        expect2(multiple.total).toEqual(3);
+        expect2(multiple.success.length).toEqual(3);
+        expect2(multiple.failed.length).toEqual(0);
+        expect2(() => multiple.success[0], 'id,name').toEqual({ id: 'U00002', name: 'test2' });
+        expect2(() => multiple.success[1], 'id,name').toEqual({ id: 'U00003', name: 'test3' });
+        expect2(() => multiple.success[2], 'id,name').toEqual({ id: 'U00004', name: 'test4' });
+
+        // - update existing items (modify)
+        const updated = await $account.mupdate([
+            { id: 'U00001', name: 'updated1', balance: 150 },
+            { id: 'U00002', name: 'updated2', balance: 250 },
+        ]);
+        expect2(updated.total).toEqual(2);
+        expect2(updated.success.length).toEqual(2);
+        expect2(() => updated.success[0], 'id,name,balance').toEqual({ id: 'U00001', name: 'updated1', balance: 150 });
+        expect2(() => updated.success[1], 'id,name,balance').toEqual({ id: 'U00002', name: 'updated2', balance: 250 });
+
+        // - verify updates
+        const verified2 = await $account.read('U00001');
+        expect2(() => verified2, 'id,name,balance').toEqual({ id: 'U00001', name: 'updated1', balance: 150 });
+
+        const verified3 = await $account.read('U00002');
+        expect2(() => verified3, 'id,name,balance').toEqual({ id: 'U00002', name: 'updated2', balance: 250 });
+
+        // - cleanup
+        await $account.delete('U00001');
+        await $account.delete('U00002');
+        await $account.delete('U00003');
+        await $account.delete('U00004');
+    });
+
     //* dummy storage service.
     it('should pass dummy storage-service', async () => {
         //* load dummy storage service.
@@ -192,6 +346,156 @@ describe('StorageService', () => {
             type: 'test',
             slot: 1,
         });
+    });
+
+    //* dynamo storage service - mread tests
+    it('should pass dynamo storage-service mread operations', async () => {
+        //* load dynamo storage service
+        const $dynamo = new DynamoStorageService<AccountModel>('TestTable', ['name', 'slot', 'balance'], 'no');
+
+        //* ignore if not in 'lemon'
+        if (PROFILE !== 'lemon') {
+            console.info(`! ignored by profile[${PROFILE}] (expected of 'lemon')`);
+            return;
+        }
+
+        //* mread test
+        // 1. validate ids parameter test
+        // - null ids
+        const nullResult = await $dynamo.mread(null as any);
+        expect2(nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - undefined ids
+        const undefinedResult = await $dynamo.mread(undefined as any);
+        expect2(undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - empty array
+        const emptyResult = await $dynamo.mread([]);
+        expect2(emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // 2. success cases
+        // - setup test data
+        await $dynamo.save('DM00001', { type: 'account', name: 'user1', balance: 100 });
+        testDataIds.add('DM00001');
+        await $dynamo.save('DM00002', { type: 'account', name: 'user2', balance: 200 });
+        testDataIds.add('DM00002');
+        await $dynamo.save('DM00003', { type: 'account', name: 'user3', balance: 300 });
+        testDataIds.add('DM00003');
+
+        // - read single existing id
+        const single = await $dynamo.mread(['DM00001']);
+        expect2(single.total).toEqual(1);
+        expect2(single.success.length).toEqual(1);
+        expect2(single.failed.length).toEqual(0);
+        expect2(() => single.success[0], 'no,name,balance').toEqual({ no: 'DM00001', name: 'user1', balance: 100 });
+
+        // - read multiple existing ids
+        const multiple = await $dynamo.mread(['DM00001', 'DM00002', 'DM00003']);
+        expect2(multiple.total).toEqual(3);
+        expect2(multiple.success.length).toEqual(3);
+        expect2(multiple.failed.length).toEqual(0);
+        expect2(() => multiple.success[0], 'no,name').toEqual({ no: 'DM00001', name: 'user1' });
+        expect2(() => multiple.success[1], 'no,name').toEqual({ no: 'DM00002', name: 'user2' });
+        expect2(() => multiple.success[2], 'no,name').toEqual({ no: 'DM00003', name: 'user3' });
+
+        // - read mixed (existing and non-existing ids)
+        const mixed = await $dynamo.mread(['DM00001', 'NOTFOUND1', 'DM00002', 'NOTFOUND2']);
+        expect2(mixed.total).toEqual(4);
+        expect2(mixed.success.length).toEqual(2);
+        expect2(mixed.failed.length).toEqual(2);
+        expect2(() => mixed.success[0], 'no,name').toEqual({ no: 'DM00001', name: 'user1' });
+        expect2(() => mixed.success[1], 'no,name').toEqual({ no: 'DM00002', name: 'user2' });
+        expect2(() => mixed.failed[0], 'no').toEqual({ no: 'NOTFOUND1' });
+        expect2(() => mixed.failed[1], 'no').toEqual({ no: 'NOTFOUND2' });
+
+        // - read all non-existing ids
+        const allFailed = await $dynamo.mread(['NOTFOUND1', 'NOTFOUND2', 'NOTFOUND3']);
+        expect2(allFailed.total).toEqual(3);
+        expect2(allFailed.success.length).toEqual(0);
+        expect2(allFailed.failed.length).toEqual(3);
+    });
+
+    //* dynamo storage service - mupdate tests
+    it('should pass dynamo storage-service mupdate operations', async () => {
+        //* load dynamo storage service
+        const $dynamo = new DynamoStorageService<AccountModel>('TestTable', ['name', 'slot', 'balance'], 'no');
+
+        //* ignore if not in 'lemon'
+        if (PROFILE !== 'lemon') {
+            console.info(`! ignored by profile[${PROFILE}] (expected of 'lemon')`);
+            return;
+        }
+
+        //* mupdate test
+        // 1. validate list parameter test
+        // - null list
+        const nullResult = await $dynamo.mupdate(null as any);
+        expect2(nullResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - undefined list
+        const undefinedResult = await $dynamo.mupdate(undefined as any);
+        expect2(undefinedResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // - empty array
+        const emptyResult = await $dynamo.mupdate([]);
+        expect2(emptyResult).toEqual({ success: [], failed: [], total: 0 });
+
+        // 2. match error cases
+        // - missing id in item (using 'no' as idName)
+        expect2(await $dynamo.mupdate([{ type: 'account', name: 'test' } as any]).catch(GETERR)).toEqual(
+            '@id is required!',
+        );
+
+        // - item without id field
+        expect2(
+            await $dynamo.mupdate([{ type: 'account', balance: 100 }, { type: 'account' }] as any).catch(GETERR),
+        ).toEqual('@id is required!');
+
+        // 3. success cases
+        // - update single item (create new)
+        const single = await $dynamo.mupdate([{ no: 'DU00001', type: 'account', name: 'test1', balance: 100 } as any]);
+        testDataIds.add('DU00001');
+        expect2(single.total).toEqual(1);
+        expect2(single.success.length).toEqual(1);
+        expect2(single.failed.length).toEqual(0);
+        expect2(() => single.success[0], 'no,name,balance').toEqual({ no: 'DU00001', name: 'test1', balance: 100 });
+
+        // - verify saved
+        const verified1 = await $dynamo.read('DU00001');
+        expect2(() => verified1, 'no,name,balance').toEqual({ no: 'DU00001', name: 'test1', balance: 100 });
+
+        // - update multiple items
+        const multiple = await $dynamo.mupdate([
+            { no: 'DU00002', type: 'account', name: 'test2', balance: 200 } as any,
+            { no: 'DU00003', type: 'account', name: 'test3', balance: 300 } as any,
+            { no: 'DU00004', type: 'account', name: 'test4', balance: 400 } as any,
+        ]);
+        testDataIds.add('DU00002');
+        testDataIds.add('DU00003');
+        testDataIds.add('DU00004');
+        expect2(multiple.total).toEqual(3);
+        expect2(multiple.success.length).toEqual(3);
+        expect2(multiple.failed.length).toEqual(0);
+        expect2(() => multiple.success[0], 'no,name').toEqual({ no: 'DU00002', name: 'test2' });
+        expect2(() => multiple.success[1], 'no,name').toEqual({ no: 'DU00003', name: 'test3' });
+        expect2(() => multiple.success[2], 'no,name').toEqual({ no: 'DU00004', name: 'test4' });
+
+        // - update existing items (modify)
+        const updated = await $dynamo.mupdate([
+            { no: 'DU00001', name: 'updated1', balance: 150 } as any,
+            { no: 'DU00002', name: 'updated2', balance: 250 } as any,
+        ]);
+        expect2(updated.total).toEqual(2);
+        expect2(updated.success.length).toEqual(2);
+        expect2(() => updated.success[0], 'no,name,balance').toEqual({ no: 'DU00001', name: 'updated1', balance: 150 });
+        expect2(() => updated.success[1], 'no,name,balance').toEqual({ no: 'DU00002', name: 'updated2', balance: 250 });
+
+        // - verify updates
+        const verified2 = await $dynamo.read('DU00001');
+        expect2(() => verified2, 'no,name,balance').toEqual({ no: 'DU00001', name: 'updated1', balance: 150 });
+
+        const verified3 = await $dynamo.read('DU00002');
+        expect2(() => verified3, 'no,name,balance').toEqual({ no: 'DU00002', name: 'updated2', balance: 250 });
     });
 
     //* dynamo storage service. (should be equivalent with `dummy-storage-server`)
@@ -392,5 +696,13 @@ describe('StorageService', () => {
             type: 'test',
             slot: 1,
         });
+    });
+
+    afterAll(async () => {
+        if (PROFILE !== 'lemon') return;
+
+        // Cleanup the table - delete all test data
+        const $dynamo = new DynamoStorageService<AccountModel>('TestTable', ['name', 'slot', 'balance'], 'no');
+        await Promise.all([...testDataIds].map(id => $dynamo.delete(id).catch(() => {})));
     });
 });

--- a/src/cores/storage/storage-service.ts
+++ b/src/cores/storage/storage-service.ts
@@ -82,7 +82,7 @@ export interface StorageService<T extends StorageModel> {
 /** ****************************************************************************************************************
  *  Data Storage Service
  ** ****************************************************************************************************************/
-import { DynamoService, KEY_TYPE } from '../dynamo/';
+import { DynamoService, KEY_TYPE, BatchResult } from '../dynamo/';
 import { loadDataYml } from '../../tools/';
 
 interface MyGeneral extends GeneralItem, StorageModel {}
@@ -136,6 +136,31 @@ export class DynamoStorageService<T extends StorageModel> implements StorageServ
             return N;
         }, {});
         return item;
+    }
+
+    /**
+     * Read multiple models via database.
+     *
+     * @param ids       ids
+     */
+    public async mread(ids: string[]): Promise<BatchResult<T>> {
+        const total = ids?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!ids || total === 0) return result;
+
+        const list = ids.map(id => ({ id }));
+        const res = await this.$dynamo.mreadItem(list);
+        const fields = this._fields || [];
+        const toModel = (data: MyGeneral): T =>
+            fields.reduce((N: any, key) => {
+                const val = (data as any)[key];
+                if (val !== undefined) N[key] = val;
+                return N;
+            }, {});
+
+        result.success = (res.success || []).map(toModel);
+        result.failed = (res.failed || []).map(toModel);
+        return result;
     }
 
     /**
@@ -193,6 +218,41 @@ export class DynamoStorageService<T extends StorageModel> implements StorageServ
         /* eslint-enable prettier/prettier */
         const ret: any = await this.$dynamo.updateItem(id, undefined, $U, $I);
         return ret as T;
+    }
+
+    /**
+     * update multiple models
+     *
+     * @param list      list of models (should include id)
+     */
+    public async mupdate(list: T[]): Promise<BatchResult<T>> {
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        const fields = this._fields || [];
+        const items = list.map((item: T) => {
+            const _id = (item as any)[this._idName] || (item as any).id;
+            if (!_id) throw new Error('@id is required!');
+            const data: MyGeneral = fields.reduce((N: any, key) => {
+                const val = (item as any)[key];
+                if (val !== undefined) N[key] = val;
+                return N;
+            }, {});
+            return { id: `${_id}`, ...data };
+        });
+
+        const res = await this.$dynamo.mupdateItem(items);
+        const toModel = (data: MyGeneral): T =>
+            fields.reduce((N: any, key) => {
+                const val = (data as any)[key];
+                if (val !== undefined) N[key] = val;
+                return N;
+            }, {});
+
+        result.success = (res.success || []).map(toModel);
+        result.failed = (res.failed || []).map(toModel);
+        return result;
     }
 
     /**
@@ -291,6 +351,24 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         return { ...item, [this.idName]: id } as T;
     }
 
+    public async mread(ids: string[]): Promise<BatchResult<T>> {
+        const total = ids?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!ids || total === 0) return result;
+
+        for (const id of ids) {
+            if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
+            const item = this.buffer[id];
+            if (!item) {
+                result.failed.push({ [this.idName]: id } as unknown as T);
+            } else {
+                result.success.push({ ...item, [this.idName]: id } as T);
+            }
+        }
+
+        return result;
+    }
+
     protected async readSafe(id: string): Promise<T> {
         return this.read(id).catch(e => {
             if (`${e.message || e}`.startsWith('404 NOT FOUND')) {
@@ -348,6 +426,22 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         const $set = { ...item, ...incremented };
         if (typeof $set.lock == 'number') ($set as any).lock = lock;
         return Object.assign({ [this.idName]: id }, $set);
+    }
+
+    public async mupdate(list: T[]): Promise<BatchResult<T>> {
+        const total = list?.length ?? 0;
+        const result: BatchResult<T> = { success: [], failed: [], total };
+        if (!list || total === 0) return result;
+
+        for (const item of list) {
+            const _id = (item as any)[this.idName] || (item as any).id;
+            if (!_id) throw new Error('@id is required!');
+            if (item && typeof (item as any).lock == 'number') this.$locks[_id] = (item as any).lock;
+            this.buffer[_id] = item;
+            result.success.push({ ...item, [this.idName]: _id } as T);
+        }
+
+        return result;
     }
 
     public async increment(id: string, $inc: T, $upt?: T): Promise<T> {

--- a/src/extended/abstract-service.spec.ts
+++ b/src/extended/abstract-service.spec.ts
@@ -25,7 +25,6 @@ import {
     ManagerProxy,
 } from './abstract-service';
 import { asyncCredentials } from '../tools';
-
 /**
  * type: `Model`
  */
@@ -339,5 +338,283 @@ describe('abstract-service', () => {
                 signature: 'v1:84g6M+IU2X/yfcyYqUxNAgQPKYlnucbWrPhP+hFYXUE=',
             },
         });
+    });
+    it('should pass saveAllUpdates()', async () => {
+        //* ignore if not in 'lemon'
+        if (PROFILE !== 'lemon') {
+            console.info(`! ignored by profile[${PROFILE}] (expected of 'lemon')`);
+            return;
+        }
+
+        const { service } = instance();
+        const proxy = service.buildProxy({ domain: 'test', source: 'test' });
+
+        //* test of options parameter validation
+        // undefined options (should use defaults)
+        const proxy1 = service.buildProxy({ domain: 'test', source: 'test' });
+        const model1 = await proxy1.tests.get('item-undefined-test', {});
+        model1.name = 'undefined options';
+        await proxy1.saveAllUpdates();
+        const retrieved1 = await proxy1.tests.get('item-undefined-test');
+        expect2(() => retrieved1, 'name').toEqual({ name: 'undefined options' });
+
+        // empty options object
+        const proxy2 = service.buildProxy({ domain: 'test', source: 'test' });
+        const model2 = await proxy2.tests.get('item-empty-opts', {});
+        model2.name = 'empty opts';
+        await proxy2.saveAllUpdates({});
+        const retrieved2 = await proxy2.tests.get('item-empty-opts');
+        expect2(() => retrieved2, 'name').toEqual({ name: 'empty opts' });
+
+        //* prepare 20 test items for batch mode test
+        for (let i = 0; i < 20; i++) {
+            const model = await proxy.tests.get(`item-${i}`, {});
+            model.name = `Item ${i}`;
+            model.test = i * 10;
+        }
+
+        //* mock storage methods to count calls
+        let updateCallCount = 0;
+        let batchCallCount = 0;
+        const originalUpdate = proxy.tests.$mgr.storage.update.bind(proxy.tests.$mgr.storage);
+        const originalDoUpdateMulti = proxy.tests.$mgr.storage.storage.doUpdateMulti.bind(
+            proxy.tests.$mgr.storage.storage,
+        );
+
+        proxy.tests.$mgr.storage.update = async (id: string, model: any, inc?: any) => {
+            updateCallCount++;
+            return originalUpdate(id, model, inc);
+        };
+
+        proxy.tests.$mgr.storage.storage.doUpdateMulti = async (type: string, list: any[]) => {
+            batchCallCount++;
+            return originalDoUpdateMulti(type, list);
+        };
+
+        //* test of default mode (useBatch: true by default - batch updates)
+        const batchResult = await proxy.saveAllUpdates();
+        expect2(() => updateCallCount).toEqual(0);
+        expect2(() => batchCallCount).toEqual(1);
+        expect2(() => Array.isArray(batchResult)).toEqual(true);
+        expect2(() => batchResult.length).toEqual(20);
+
+        //* test of explicit batch mode with useBatch: true
+        updateCallCount = 0;
+        batchCallCount = 0;
+        const proxyExplicit = service.buildProxy({ domain: 'test', source: 'test' });
+        for (let i = 0; i < 5; i++) {
+            const model = await proxyExplicit.tests.get(`item-explicit-${i}`, {});
+            model.name = `Explicit ${i}`;
+        }
+        await proxyExplicit.saveAllUpdates({ useBatch: true });
+
+        //* prepare 20 test items again for legacy test
+        const proxyLegacy = service.buildProxy({ domain: 'test', source: 'test' });
+        let legacyUpdateCount = 0;
+        let legacyBatchCount = 0;
+        const originalUpdateLegacy = proxyLegacy.tests.$mgr.storage.update.bind(proxyLegacy.tests.$mgr.storage);
+        const originalDoUpdateMultiLegacy = proxyLegacy.tests.$mgr.storage.storage.doUpdateMulti.bind(
+            proxyLegacy.tests.$mgr.storage.storage,
+        );
+
+        proxyLegacy.tests.$mgr.storage.update = async (id: string, model: any, inc?: any) => {
+            legacyUpdateCount++;
+            return originalUpdateLegacy(id, model, inc);
+        };
+
+        proxyLegacy.tests.$mgr.storage.storage.doUpdateMulti = async (type: string, list: any[]) => {
+            legacyBatchCount++;
+            return originalDoUpdateMultiLegacy(type, list);
+        };
+
+        for (let i = 0; i < 20; i++) {
+            const model = await proxyLegacy.tests.get(`item-legacy-${i}`, {});
+            model.name = `Item ${i} v2`;
+            model.test = i * 100;
+        }
+
+        //* test of legacy mode (useBatch: false - individual updates)
+        const legacyResult = await proxyLegacy.saveAllUpdates({ useBatch: false });
+        expect2(() => legacyUpdateCount).toEqual(20);
+        expect2(() => legacyBatchCount).toEqual(0);
+        expect2(() => Array.isArray(legacyResult)).toEqual(true);
+
+        //* test of onlyValid option with batch mode
+        const proxyValid = service.buildProxy({ domain: 'test', source: 'test' });
+        const modelWithNull = await proxyValid.tests.get('item-null-test', {});
+        modelWithNull.name = 'valid name';
+        modelWithNull.test = null as any;
+        await proxyValid.saveAllUpdates({ onlyValid: true });
+        const retrievedValid = await proxyValid.tests.get('item-null-test');
+        expect2(() => retrievedValid, 'name').toEqual({ name: 'valid name' });
+
+        //* test of parrallel option (legacy mode)
+        const proxyParrallel = service.buildProxy({ domain: 'test', source: 'test' });
+        let parallelUpdateCallCount = 0;
+        const originalUpdateParrallel = proxyParrallel.tests.$mgr.storage.update.bind(
+            proxyParrallel.tests.$mgr.storage,
+        );
+        proxyParrallel.tests.$mgr.storage.update = async (id: string, model: any, inc?: any) => {
+            parallelUpdateCallCount++;
+            return originalUpdateParrallel(id, model, inc);
+        };
+
+        for (let i = 0; i < 10; i++) {
+            const model = await proxyParrallel.tests.get(`item-parrallel-${i}`, {});
+            model.name = `Parrallel ${i}`;
+        }
+        await proxyParrallel.saveAllUpdates({ useBatch: false, parrallel: 5 });
+        expect2(() => parallelUpdateCallCount).toEqual(10);
+
+        //* test of empty update set
+        const proxyEmpty = service.buildProxy({ domain: 'test', source: 'test' });
+        const emptyResult = await proxyEmpty.saveAllUpdates();
+        expect2(() => emptyResult).toEqual([]);
+
+        //* test of single item update (batch mode)
+        const proxySingle = service.buildProxy({ domain: 'test', source: 'test' });
+        let singleBatchCount = 0;
+        const originalDoUpdateMultiSingle = proxySingle.tests.$mgr.storage.storage.doUpdateMulti.bind(
+            proxySingle.tests.$mgr.storage.storage,
+        );
+        proxySingle.tests.$mgr.storage.storage.doUpdateMulti = async (type: string, list: any[]) => {
+            singleBatchCount++;
+            return originalDoUpdateMultiSingle(type, list);
+        };
+
+        const singleModel = await proxySingle.tests.get('item-single', {});
+        singleModel.name = 'single item';
+        await proxySingle.saveAllUpdates({ useBatch: true });
+        expect2(() => singleBatchCount).toEqual(1);
+
+        //* test of result comparison between batch mode and legacy mode
+        //* STEP.1: prepare test data for batch mode
+        const proxyBatchCompare = service.buildProxy({ domain: 'test', source: 'test' });
+        const batchTestItems = [];
+        for (let i = 0; i < 10; i++) {
+            const model = await proxyBatchCompare.tests.get(`batch-compare-${i}`, {});
+            model.name = `Batch Item ${i}`;
+            model.test = i * 100;
+            batchTestItems.push({ id: `batch-compare-${i}`, name: `Batch Item ${i}`, test: i * 100 });
+        }
+
+        //* STEP.2: save with batch mode (useBatch: true)
+        const batchModeResult = await proxyBatchCompare.saveAllUpdates({ useBatch: true });
+
+        //* STEP.3: verify batch mode results
+        expect2(() => Array.isArray(batchModeResult)).toEqual(true);
+        expect2(() => batchModeResult.length).toEqual(10);
+
+        //* STEP.4: retrieve and verify batch mode saved data
+        const batchRetrievedItems = [];
+        for (let i = 0; i < 10; i++) {
+            const retrieved = await proxyBatchCompare.tests.get(`batch-compare-${i}`);
+            batchRetrievedItems.push(retrieved);
+        }
+
+        //* STEP.5: prepare identical test data for legacy mode
+        const proxyLegacyCompare = service.buildProxy({ domain: 'test', source: 'test' });
+        const legacyTestItems = [];
+        for (let i = 0; i < 10; i++) {
+            const model = await proxyLegacyCompare.tests.get(`legacy-compare-${i}`, {});
+            model.name = `Batch Item ${i}`;
+            model.test = i * 100;
+            legacyTestItems.push({ id: `legacy-compare-${i}`, name: `Batch Item ${i}`, test: i * 100 });
+        }
+
+        //* STEP.6: save with legacy mode (useBatch: false)
+        const legacyModeResult = await proxyLegacyCompare.saveAllUpdates({ useBatch: false });
+
+        //* STEP.7: verify legacy mode results
+        expect2(() => Array.isArray(legacyModeResult)).toEqual(true);
+        expect2(() => legacyModeResult.length).toEqual(10);
+
+        //* STEP.8: retrieve and verify legacy mode saved data
+        const legacyRetrievedItems = [];
+        for (let i = 0; i < 10; i++) {
+            const retrieved = await proxyLegacyCompare.tests.get(`legacy-compare-${i}`);
+            legacyRetrievedItems.push(retrieved);
+        }
+
+        //* STEP.9: compare batch mode vs legacy mode results structure
+        expect2(() => batchModeResult.length).toEqual(legacyModeResult.length);
+        expect2(() => typeof batchModeResult).toEqual(typeof legacyModeResult);
+
+        //* STEP.10: compare retrieved data field by field
+        for (let i = 0; i < 10; i++) {
+            const batchItem = batchRetrievedItems[i];
+            const legacyItem = legacyRetrievedItems[i];
+
+            // verify name field is identical
+            expect2(() => batchItem, 'name').toEqual({ name: `Batch Item ${i}` });
+            expect2(() => legacyItem, 'name').toEqual({ name: `Batch Item ${i}` });
+
+            // verify test field is identical
+            expect2(() => batchItem, 'test').toEqual({ test: i * 100 });
+            expect2(() => legacyItem, 'test').toEqual({ test: i * 100 });
+
+            // verify both have same structure
+            expect2(() => typeof batchItem.name).toEqual('string');
+            expect2(() => typeof legacyItem.name).toEqual('string');
+            expect2(() => typeof batchItem.test).toEqual('number');
+            expect2(() => typeof legacyItem.test).toEqual('number');
+        }
+
+        //* STEP.11: verify result return value comparison
+        // both modes should return updated models with same field structure
+        const batchFirstResult = batchModeResult[0];
+        const legacyFirstResult = legacyModeResult[0];
+
+        expect2(() => typeof batchFirstResult).toEqual('object');
+        expect2(() => typeof legacyFirstResult).toEqual('object');
+        expect2(() => batchFirstResult).toEqual(expect.objectContaining({ name: expect.any(String) }));
+        expect2(() => legacyFirstResult).toEqual(expect.objectContaining({ name: expect.any(String) }));
+
+        //* STEP.12: verify update count consistency
+        // batch mode: 10 items saved in 1 call
+        // legacy mode: 10 items saved in 10 calls
+        // result: both should have 10 items saved successfully
+        expect2(() => batchRetrievedItems.length).toEqual(10);
+        expect2(() => legacyRetrievedItems.length).toEqual(10);
+        expect2(() => batchRetrievedItems.length).toEqual(legacyRetrievedItems.length);
+
+        //* STEP.13: test with complex data comparison
+        const proxyBatchComplex = service.buildProxy({ domain: 'test', source: 'test' });
+        const proxyLegacyComplex = service.buildProxy({ domain: 'test', source: 'test' });
+
+        // prepare complex data with multiple fields
+        for (let i = 0; i < 5; i++) {
+            const batchModel = await proxyBatchComplex.tests.get(`complex-batch-${i}`, {});
+            batchModel.name = `Complex ${i}`;
+            batchModel.test = i * 50;
+
+            const legacyModel = await proxyLegacyComplex.tests.get(`complex-legacy-${i}`, {});
+            legacyModel.name = `Complex ${i}`;
+            legacyModel.test = i * 50;
+        }
+
+        // save with both modes
+        await proxyBatchComplex.saveAllUpdates({ useBatch: true });
+        await proxyLegacyComplex.saveAllUpdates({ useBatch: false });
+
+        // retrieve and compare
+        for (let i = 0; i < 5; i++) {
+            const batchComplex = await proxyBatchComplex.tests.get(`complex-batch-${i}`);
+            const legacyComplex = await proxyLegacyComplex.tests.get(`complex-legacy-${i}`);
+
+            // verify identical values
+            expect2(() => batchComplex, 'name,test').toEqual({
+                name: `Complex ${i}`,
+                test: i * 50,
+            });
+            expect2(() => legacyComplex, 'name,test').toEqual({
+                name: `Complex ${i}`,
+                test: i * 50,
+            });
+
+            // verify both modes produce identical structure
+            expect2(() => batchComplex.name).toEqual(legacyComplex.name);
+            expect2(() => batchComplex.test).toEqual(legacyComplex.test);
+        }
     });
 });

--- a/src/extended/abstract-service.ts
+++ b/src/extended/abstract-service.ts
@@ -504,6 +504,92 @@ export class ManagerProxy<
     }
 
     /**
+     * read multiple nodes.
+     * @param ids list of object-ids
+     * @param throwable (optional) flag to throw error if not found
+     */
+    public async mget(ids: string[], throwable = true): Promise<(Model | null)[]> {
+        if (!ids || ids.length === 0) return [];
+
+        const result: (Model | null)[] = [];
+        const toFetch: string[] = [];
+        const indexMap: { [key: string]: number[] } = {};
+
+        //* STEP.1 check cached items
+        ids.forEach((id, index) => {
+            const err404 = `404 NOT FOUND - proxy/${this.$mgr.type}/id:${id}`;
+            //* already marked as null (404)
+            if (this._org[id] === null) {
+                if (throwable) throw new Error(err404);
+                result[index] = null;
+                return;
+            }
+            //* found in _new
+            const N = this._new[id];
+            if (N !== undefined) {
+                result[index] = N;
+                return;
+            }
+            //* need to fetch
+            if (!indexMap[id]) {
+                indexMap[id] = [];
+                toFetch.push(id);
+            }
+            indexMap[id].push(index);
+        });
+
+        //* STEP.2 batch read from storage
+        if (toFetch.length > 0) {
+            const res = await this.$mgr.storage.storage.doReadMulti(this.$mgr.type, toFetch);
+            const successMap: { [key: string]: Model } = {};
+            (res.success || []).forEach((model: Model) => {
+                const id = (model as any).id;
+                if (id) successMap[id] = model;
+            });
+
+            //* STEP.3 save to cache and build result
+            toFetch.forEach(id => {
+                const M = successMap[id];
+                if (M) {
+                    const M2 = this.normal(M);
+                    this._org[id] = M2;
+                    const M3 = JSON.parse($U.json(M2)) as Model;
+                    this._new[id] = M3;
+                    indexMap[id].forEach(index => {
+                        result[index] = M3;
+                    });
+                } else {
+                    this._org[id] = null;
+                    const err404 = `404 NOT FOUND - proxy/${this.$mgr.type}/id:${id}`;
+                    indexMap[id].forEach(index => {
+                        if (throwable) throw new Error(err404);
+                        result[index] = null;
+                    });
+                }
+            });
+        }
+
+        return result;
+    }
+
+    /**
+     * update multiple nodes.
+     * @param updates list of models (should include id)
+     */
+    public async mset(updates: Array<Model & { id: string }>): Promise<Model[]> {
+        if (!updates || updates.length === 0) return [];
+
+        const result: Model[] = [];
+        for (const model of updates) {
+            const id = model.id;
+            if (!id) throw new Error(`@id is required - proxy/${this.$mgr.type}/mset()!`);
+            const O = await this.get(id);
+            result.push(this.override(O, model));
+        }
+        return result;
+    }
+
+    /**
      * increment the field of Object[id]
      * !WARN! this incremented properties should NOT be updated later.
      */
@@ -615,12 +701,15 @@ export abstract class AbstractProxy<U extends string, T extends CoreService<Core
         parrallel?: number;
         /** (optional) flag to use only valid value (not null) (default true) */
         onlyValid?: boolean;
+        /** (optional) flag to use batch update (default false) */
+        useBatch?: boolean;
     }) {
         const parrallel = $U.N(options?.parrallel, this.parrallel);
+        const useBatch = options?.useBatch ?? false;
         type Model = CoreModel<U>;
-        type TYPE = { id: string; N: Model; _: () => Promise<Model> };
+        type TYPE = { id: string; N: Model; _: () => Promise<Model>; type?: string; storage?: any };
 
-        // STEP.1 prepare the list of updater.
+        // STEP.1 prepare the list of updater (collect type and storage info for batch mode)
         const list = this.allProxies.reduce((L: TYPE[], $p: ManagerProxy<any, CoreManager<any, any, any>>) => {
             const $set = $p.alls(true, options?.onlyValid);
             return Object.entries($set).reduce((L: TYPE[], [id, N]) => {
@@ -628,13 +717,53 @@ export abstract class AbstractProxy<U extends string, T extends CoreService<Core
                 if (hasUpdate) {
                     _log(NS, `>> ${$p.$mgr.type}/${id} =`, $U.json(N));
                     const _ = () => $p.$mgr.storage.update(id, N);
-                    L.push({ id, N, _ });
+                    L.push({ id, N, _, type: $p.$mgr.type, storage: $p.$mgr.storage });
                 }
                 return L;
             }, L);
         }, []);
 
         // STEP.2 finally update storage.
+        if (useBatch) {
+            //* NEW: batch update mode
+            _log(NS, `> saveAllUpdates: using batch mode (${list.length} items)`);
+
+            //* group by type from pre-collected list (no duplicate traversal)
+            const grouped = new Map<string, { storage: any; items: Array<Model & { id: string }> }>();
+            list.forEach(({ id, N, type, storage }) => {
+                if (!grouped.has(type!)) {
+                    grouped.set(type!, { storage, items: [] });
+                }
+                grouped.get(type!)!.items.push({ ...(N as Model), id });
+            });
+
+            //* execute batch updates
+            const results = await Promise.all(
+                Array.from(grouped.entries()).map(([type, { storage, items }]) =>
+                    storage.storage.doUpdateMulti(type, items),
+                ),
+            );
+
+            //* flatten BatchResult[] to Model[]
+            const allItems: Model[] = [];
+            let totalFailed = 0;
+            results.forEach(result => {
+                allItems.push(...result.success);
+                totalFailed += result.failed.length;
+                if (result.failed.length > 0) {
+                    _log(NS, `! batch update failed: ${result.failed.length} items`, result.failed);
+                }
+            });
+            _log(
+                NS,
+                `> saveAllUpdates: success=${allItems.length}, failed=${totalFailed}, total=${
+                    allItems.length + totalFailed
+                }`,
+            );
+            return allItems;
+        }
+
+        //* LEGACY: original parallel update (default behavior)
         return my_parrallel(
             list,
             async (N: any) => {


### PR DESCRIPTION
# feat: Add DynamoDB Batch Operations Support

## Overview

DynamoDB의 배치 연산(BatchGetItem, BatchWriteItem)을 활용하여 다중 CRUD 작업의 성능을 향상시켰습니다.

## 주요 변경사항

### 1. DynamoDB 배치 연산 구현
- **`mreadItem()`**: BatchGetItem을 사용한 다중 읽기 (최대 100개/요청)
- **`mupdateItem()`**: BatchWriteItem을 사용한 다중 쓰기 (최대 25개/요청)
- **`msaveItem()`**: BatchWriteItem을 사용한 다중 저장 (최대 25개/요청)
- **자동 청킹**: 제한을 초과하는 요청은 자동으로 분할 처리
- **재시도 로직**: 실패한 항목에 대해 exponential backoff로 최대 3회 재시도

### 2. Storage Service 레이어 배치 지원
- **`doReadMulti()`**: 타입별 다중 모델 읽기
- **`doUpdateMulti()`**: 타입별 다중 모델 업데이트
- **`mread()`**, **`mupdate()`**: 하위 레이어 배치 연산 인터페이스

### 3. AbstractService 배치 업데이트 최적화
- **`saveAllUpdates({ useBatch: true })`**: 타입별 그룹화 후 배치 처리
- **기본값**: `useBatch: false` (하위 호환성 유지)

## 새로운 기능

### 1. DynamoDB 배치 읽기
```typescript
const dynamo = new DynamoService('MyTable', '_id');
const result = await dynamo.mreadItem(['id1', 'id2', 'id3']);
// BatchResult<T> = { success: T[], failed: T[], total: number }
console.log(`성공: ${result.success.length}, 실패: ${result.failed.length}`);
```

### 2. DynamoDB 배치 업데이트
```typescript
const items = [
  { _id: 'id1', name: 'Item 1' },
  { _id: 'id2', name: 'Item 2' },
  { _id: 'id3', name: 'Item 3' }
];
const result = await dynamo.mupdateItem(items);
```

### 3. Storage Service 배치 연산
```typescript
const storage = new ProxyStorageService(...);

// 다중 읽기
const readResult = await storage.doReadMulti('user', ['id1', 'id2', 'id3']);

// 다중 업데이트
const updateResult = await storage.doUpdateMulti('user', [
  { id: 'id1', name: 'Updated 1' },
  { id: 'id2', name: 'Updated 2' }
]);
```

### 4. AbstractService 배치 업데이트
```typescript
const proxy = service.buildProxy({ domain: 'test', source: 'test' });

// 여러 모델 수정
const user = await proxy.users.get('user1', {});
user.name = 'Updated';

const product = await proxy.products.get('prod1', {});
product.price = 1000;

// 배치 모드로 저장 (타입별로 자동 그룹화)
await proxy.saveAllUpdates({ useBatch: true });

// 레거시 모드로 저장 (기존 방식)
await proxy.saveAllUpdates({ useBatch: false }); // 기본값
```

## ⚠️ saveAllUpdates 유의사항

### 사용법

```typescript
// 기본값 (Legacy 모드 - 하위 호환성 유지)
await proxy.saveAllUpdates();
await proxy.saveAllUpdates({ useBatch: false });

// Batch 모드 (성능 최적화)
await proxy.saveAllUpdates({ useBatch: true });
```

### 동작 차이

| 항목 | Legacy (false) | Batch (true) |
|------|---------------|--------------|
| **반환값** | 성공 + 실패 혼합 배열 | 성공만 포함 |
| **실패 항목** | `{id, error}` 형태로 포함 | 로그만 출력 후 제외 |
| **배열 길이** | 전체 항목 수 | 성공한 항목 수 |
| **에러 감지** | 가능 (`error` 필드 확인) | 불가능 |
| **성능** | 개별 업데이트 (느림) | 배치 업데이트 (빠름) |

### 에러 처리 예시

```typescript
// Legacy 모드: 실패 항목도 결과에 포함
const results = await proxy.saveAllUpdates({ useBatch: false });
const failed = results.filter(r => r.error);  // 실패 항목 확인 가능
console.log(`성공: ${results.length - failed.length}, 실패: ${failed.length}`);

// Batch 모드: 성공 항목만 반환, 실패는 로그만
const results = await proxy.saveAllUpdates({ useBatch: true });
console.log(`성공: ${results.length}`);  // 실패 개수는 알 수 없음
// 실패는 로그에서만 확인: "! batch update failed: 5 items"
```

### 제약사항

- ✅ **읽기**: 최대 100개/요청 (자동 청킹)
- ✅ **쓰기**: 최대 25개/요청 (자동 청킹)
- ❌ **incrementals**: Batch 모드에서 미지원 (DynamoDB API 제약)