### PR TITLE
refac: align dummy storage with dynamo parity

### DIFF
--- a/src/cores/dynamo/dynamo-service.ts
+++ b/src/cores/dynamo/dynamo-service.ts
@@ -93,9 +93,9 @@ const instance = () => {
 };
 
 //* normalize dynamo properties.
-const normalize = <T = any>(data: T): T => {
+const normalize = <T = any>(data?: T | null): T | null => {
     if (data === '') return null;
-    if (!data) return data;
+    if (!data) return null;
     if (Array.isArray(data)) return data.map(normalize) as T;
     if (typeof data == 'object') {
         return Object.keys(data).reduce((O: any, key) => {
@@ -243,12 +243,14 @@ export class DynamoService<T extends GeneralItem> {
      */
     public prepareSaveItem(id: string, item: T) {
         const { tableName, idName, sortName } = this.options;
+        const errScope = `prepareSaveItem(${idName}:${id})`;
         // _log(NS, `prepareSaveItem(${tableName})...`);
         // item && _log(NS, '> item =', item);
-        if (sortName && item[sortName] === undefined) throw new Error(`.${sortName} is required. ${idName}:${id}`);
+        if (sortName && item[sortName] === undefined) throw new Error(`.${sortName} is required - ${errScope}`);
         delete item[idName]; // clear the saved id.
         const node: T = Object.assign({ [idName]: id }, item); // copy
         const data = normalize(node);
+        if (data === null) throw new Error(`@data[null] is invalid  - ${errScope}`);
         //* prepare payload.
         const payload = {
             TableName: tableName,
@@ -265,7 +267,8 @@ export class DynamoService<T extends GeneralItem> {
      */
     public prepareItemKey(id: string, sort: any) {
         const { tableName, idName, sortName } = this.options;
-        if (!id) throw new Error(`@id is required - prepareItemKey(${tableName}/${idName})`);
+        const errScope = `prepareItemKey(${tableName}/${idName}/${id ?? ''})`;
+        if (!id?.trim()) throw new Error(`@id (string) is required - ${errScope}`);
         // _log(NS, `prepareItemKey(${tableName}/${id}/${sort || ''})...`);
         //* prepare payload.
         const payload = {
@@ -275,7 +278,7 @@ export class DynamoService<T extends GeneralItem> {
             },
         };
         if (sortName) {
-            if (sort === undefined) throw new Error(`@sort is required. ${idName}:${id}`);
+            if (sort === undefined) throw new Error(`@sort (any) is required - ${errScope}`);
             payload.Key[sortName] = sort;
         }
         return payload;
@@ -525,7 +528,10 @@ export class DynamoService<T extends GeneralItem> {
                 Array.from(chunkKeyMap.entries())
                     .filter(([sig]) => !received.has(sig) && !unprocessedSigs.has(sig))
                     .forEach(([sig, key]) => {
-                        const failedItem = { ...key, error: `404 NOT FOUND - ${idName}:${key[idName]}` } as FailedItem<T>;
+                        const failedItem = {
+                            ...key,
+                            error: `404 NOT FOUND - ${idName}:${key[idName]}`,
+                        } as FailedItem<T>;
                         failedMap.set(sig, failedItem);
                     });
             } catch (e) {
@@ -642,7 +648,7 @@ export class DynamoService<T extends GeneralItem> {
                     });
 
                 //* check for unprocessed items
-                const unprocessed = response.UnprocessedItems?.[tableName];
+                const unprocessed: any = response.UnprocessedItems?.[tableName];
                 if (unprocessed && unprocessed?.length > 0) {
                     if (attempt >= MAX_RETRIES) {
                         return unprocessed;
@@ -823,7 +829,7 @@ export class DynamoService<T extends GeneralItem> {
                     });
 
                 //* check for unprocessed items
-                const unprocessed = response.UnprocessedItems?.[tableName];
+                const unprocessed: any = response.UnprocessedItems?.[tableName];
                 if (unprocessed && unprocessed?.length > 0) {
                     if (attempt >= MAX_RETRIES) {
                         return unprocessed;
@@ -925,7 +931,7 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
         this.load(dummy.data as any);
     }
 
-    private buffer: { [id: string]: T } = {};
+    private buffer: { [id: string]: T | null } = {};
     public load(data: T[]) {
         const { idName } = this.options;
         if (!data || !Array.isArray(data)) throw new Error('@data should be array!');
@@ -958,9 +964,9 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
 
     public async readItem(id: string, sort?: string | number): Promise<T> {
         const { idName } = this.options;
-        const item: T = this.buffer[id];
+        const item = this.buffer[id];
         if (item === undefined) throw new Error(`404 NOT FOUND - ${idName}:${id}`);
-        return { [idName]: id, ...item };
+        return { [idName]: id, ...item } as T;
     }
 
     public async mreadItem(list: Array<{ id: string; sort?: string | number }>): Promise<BatchResult<T>> {
@@ -970,7 +976,7 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
         if (!list || total === 0) return result;
 
         for (const item of list) {
-            const data: T = this.buffer[item.id];
+            const data = this.buffer[item.id];
             if (data === undefined) {
                 const failedItem = (
                     sortName
@@ -1003,7 +1009,7 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
     public async saveItem(id: string, item: T): Promise<T> {
         const { idName } = this.options;
         this.buffer[id] = normalize(item);
-        return { [idName]: id, ...this.buffer[id] };
+        return { [idName]: id, ...this.buffer[id] } as T;
     }
 
     public async msaveItem(list: Array<T & { id: string; sort?: string | number }>): Promise<BatchResult<T>> {
@@ -1045,14 +1051,14 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
 
     public async deleteItem(id: string, sort?: string | number): Promise<T> {
         delete this.buffer[id];
-        return null;
+        return null as any;
     }
 
     public async updateItem(id: string, sort: string | number, updates: T, increments?: Incrementable): Promise<T> {
         const { idName } = this.options;
-        const item: T = this.buffer[id];
+        const item = this.buffer[id];
         if (item === undefined) throw new Error(`404 NOT FOUND - ${idName}:${id}`);
-        this.buffer[id] = { ...item, ...normalize(updates) };
+        this.buffer[id] = { ...item, ...normalize(updates) } as T;
         return { [idName]: id, ...this.buffer[id] };
     }
 

--- a/src/cores/dynamo/dynamo-service.ts
+++ b/src/cores/dynamo/dynamo-service.ts
@@ -93,9 +93,9 @@ const instance = () => {
 };
 
 //* normalize dynamo properties.
-const normalize = <T = any>(data?: T | null): T | null => {
-    if (data === '') return null;
-    if (!data) return null;
+const normalize = <T = any>(data?: T | null): T => {
+    if (data === '') return null as T;
+    if (!data) return data as T;
     if (Array.isArray(data)) return data.map(normalize) as T;
     if (typeof data == 'object') {
         return Object.keys(data).reduce((O: any, key) => {
@@ -250,7 +250,9 @@ export class DynamoService<T extends GeneralItem> {
         delete item[idName]; // clear the saved id.
         const node: T = Object.assign({ [idName]: id }, item); // copy
         const data = normalize(node);
-        if (data === null) throw new Error(`@data[null] is invalid  - ${errScope}`);
+        //TODO [Steve] check if how works for undefined | null in real dynamo?!
+        // if (data === null) throw new Error(`@data[null] is invalid  - ${errScope}`);
+        // if (data === undefined) throw new Error(`@data[null] is invalid  - ${errScope}`);
         //* prepare payload.
         const payload = {
             TableName: tableName,

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -16,6 +16,7 @@ interface AccountModel extends StorageModel {
     slot?: number;
     balance?: number;
     name?: string;
+    tags?: string[];
     no?: string; // for DynamoStorageService with 'no' as idName
 }
 
@@ -49,10 +50,14 @@ describe('StorageService', () => {
 
         // 2. match error cases
         // - invalid id (empty string) in array
-        expect2(await $account.mread(['', 'A00000']).catch(GETERR)).toEqual('@id (string) is required!');
+        expect2(await $account.mread(['', 'A00000']).catch(GETERR)).toEqual('@id is required!');
 
-        // - invalid id (whitespace only) in array
-        expect2(await $account.mread(['  ', 'A00000']).catch(GETERR)).toEqual('@id (string) is required!');
+        // - whitespace id is treated as a normal key, matching DynamoStorage.
+        expect2(await $account.mread(['  ', 'A00000'])).toEqual({
+            success: [{ id: 'A00000', type: 'account' }],
+            failed: [{ id: '  ', error: '404 NOT FOUND - id:  ' }],
+            total: 2,
+        });
 
         // 3. success cases
         // - setup test data
@@ -222,9 +227,21 @@ describe('StorageService', () => {
         await $account.save('equiv-update-3', initialItems[2] as AccountModel);
 
         // Legacy: multiple update calls
-        const dummyLegacyUpdate1 = await $account.update('equiv-update-1', { type: 'equiv-updated', name: 'Updated 1', balance: 200 });
-        const dummyLegacyUpdate2 = await $account.update('equiv-update-2', { type: 'equiv-updated', name: 'Updated 2', balance: 400 });
-        const dummyLegacyUpdate3 = await $account.update('equiv-update-3', { type: 'equiv-updated', name: 'Updated 3', balance: 600 });
+        const dummyLegacyUpdate1 = await $account.update('equiv-update-1', {
+            type: 'equiv-updated',
+            name: 'Updated 1',
+            balance: 200,
+        });
+        const dummyLegacyUpdate2 = await $account.update('equiv-update-2', {
+            type: 'equiv-updated',
+            name: 'Updated 2',
+            balance: 400,
+        });
+        const dummyLegacyUpdate3 = await $account.update('equiv-update-3', {
+            type: 'equiv-updated',
+            name: 'Updated 3',
+            balance: 600,
+        });
 
         // Reset data for batch test
         await $account.save('equiv-update-1', initialItems[0] as AccountModel);
@@ -339,7 +356,8 @@ describe('StorageService', () => {
 
         //* error cases.
         expect2(await $account.increment('', { type: 'test', slot: 1 }).catch(GETERR)).toEqual('@id is required!');
-        expect2(await $account.increment(' ', { type: 'test', slot: 1 }).catch(GETERR)).toEqual('@id (string) is required!');
+        expect2(await $account.increment(' ', { type: 'test', slot: 1 })).toEqual({ id: ' ', type: 'test', slot: 1 });
+        await $account.delete(' ');
         expect2(await $account.increment('B00001', null).catch(GETERR)).toEqual('@item is required!');
         expect2(await $account.increment('B00001', { type: 'test', slot: 1 })).toEqual({
             id: 'B00001',
@@ -424,7 +442,8 @@ describe('StorageService', () => {
 
         //* error cases.
         expect2(await $account.increment('', { type: 'test', slot: 1 }).catch(GETERR)).toEqual('@id is required!');
-        expect2(await $account.increment(' ', { type: 'test', slot: 1 }).catch(GETERR)).toEqual('@id (string) is required!');
+        expect2(await $account.increment(' ', { type: 'test', slot: 1 })).toEqual({ _id: ' ', type: 'test', slot: 1 });
+        await $account.delete(' ');
         expect2(await $account.increment('B00001', null).catch(GETERR)).toEqual('@item is required!');
         expect2(await $account.increment('B00001', { type: 'test', slot: 1 })).toEqual({
             _id: 'B00001',
@@ -614,7 +633,11 @@ describe('StorageService', () => {
         const dynamoLegacy3 = await $dynamo.read('dynamo-equiv-read-3');
 
         // Batch: single mread call
-        const dynamoBatchRead = await $dynamo.mread(['dynamo-equiv-read-1', 'dynamo-equiv-read-2', 'dynamo-equiv-read-3']);
+        const dynamoBatchRead = await $dynamo.mread([
+            'dynamo-equiv-read-1',
+            'dynamo-equiv-read-2',
+            'dynamo-equiv-read-3',
+        ]);
 
         // Verify equivalence
         expect2(() => dynamoBatchRead.success.length).toEqual(3);
@@ -638,9 +661,21 @@ describe('StorageService', () => {
         testDataIds.add('dynamo-equiv-update-3');
 
         // Legacy: multiple update calls
-        const dynamoLegacyUpdate1 = await $dynamo.update('dynamo-equiv-update-1', { type: 'equiv-updated', name: 'Updated 1', balance: 200 });
-        const dynamoLegacyUpdate2 = await $dynamo.update('dynamo-equiv-update-2', { type: 'equiv-updated', name: 'Updated 2', balance: 400 });
-        const dynamoLegacyUpdate3 = await $dynamo.update('dynamo-equiv-update-3', { type: 'equiv-updated', name: 'Updated 3', balance: 600 });
+        const dynamoLegacyUpdate1 = await $dynamo.update('dynamo-equiv-update-1', {
+            type: 'equiv-updated',
+            name: 'Updated 1',
+            balance: 200,
+        });
+        const dynamoLegacyUpdate2 = await $dynamo.update('dynamo-equiv-update-2', {
+            type: 'equiv-updated',
+            name: 'Updated 2',
+            balance: 400,
+        });
+        const dynamoLegacyUpdate3 = await $dynamo.update('dynamo-equiv-update-3', {
+            type: 'equiv-updated',
+            name: 'Updated 3',
+            balance: 600,
+        });
 
         // Reset data for batch test
         await $dynamo.save('dynamo-equiv-update-1', initialItems[0] as any);
@@ -670,12 +705,24 @@ describe('StorageService', () => {
         await $dynamo.delete('dynamo-equiv-update-3');
 
         // Verify items are deleted
-        expect2(await $dynamo.read('dynamo-equiv-read-1').catch(GETERR)).toEqual('404 NOT FOUND - no:dynamo-equiv-read-1');
-        expect2(await $dynamo.read('dynamo-equiv-read-2').catch(GETERR)).toEqual('404 NOT FOUND - no:dynamo-equiv-read-2');
-        expect2(await $dynamo.read('dynamo-equiv-read-3').catch(GETERR)).toEqual('404 NOT FOUND - no:dynamo-equiv-read-3');
-        expect2(await $dynamo.read('dynamo-equiv-update-1').catch(GETERR)).toEqual('404 NOT FOUND - no:dynamo-equiv-update-1');
-        expect2(await $dynamo.read('dynamo-equiv-update-2').catch(GETERR)).toEqual('404 NOT FOUND - no:dynamo-equiv-update-2');
-        expect2(await $dynamo.read('dynamo-equiv-update-3').catch(GETERR)).toEqual('404 NOT FOUND - no:dynamo-equiv-update-3');
+        expect2(await $dynamo.read('dynamo-equiv-read-1').catch(GETERR)).toEqual(
+            '404 NOT FOUND - no:dynamo-equiv-read-1',
+        );
+        expect2(await $dynamo.read('dynamo-equiv-read-2').catch(GETERR)).toEqual(
+            '404 NOT FOUND - no:dynamo-equiv-read-2',
+        );
+        expect2(await $dynamo.read('dynamo-equiv-read-3').catch(GETERR)).toEqual(
+            '404 NOT FOUND - no:dynamo-equiv-read-3',
+        );
+        expect2(await $dynamo.read('dynamo-equiv-update-1').catch(GETERR)).toEqual(
+            '404 NOT FOUND - no:dynamo-equiv-update-1',
+        );
+        expect2(await $dynamo.read('dynamo-equiv-update-2').catch(GETERR)).toEqual(
+            '404 NOT FOUND - no:dynamo-equiv-update-2',
+        );
+        expect2(await $dynamo.read('dynamo-equiv-update-3').catch(GETERR)).toEqual(
+            '404 NOT FOUND - no:dynamo-equiv-update-3',
+        );
 
         // Remove from testDataIds since we already cleaned up
         testDataIds.delete('dynamo-equiv-read-1');
@@ -884,6 +931,221 @@ describe('StorageService', () => {
             type: 'test',
             slot: 1,
         });
+    });
+
+    //* dummy storage service - optional fields behavior
+    it('should respect optional fields parameter on DummyStorageService', async () => {
+        //* fields undefined: keep legacy no-filter mode.
+        const $unfiltered = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory', 'id');
+        await $unfiltered.save('FA0000', { type: 'account', name: 'kept', extra: 'kept' } as any);
+        expect2(await $unfiltered.read('FA0000')).toEqual({
+            id: 'FA0000',
+            type: 'account',
+            name: 'kept',
+            extra: 'kept',
+        });
+        await $unfiltered.delete('FA0000');
+
+        //* fields empty: use DynamoStorage default whitelist only.
+        const $defaults = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory', 'no', []);
+        expect2(() => $defaults.hello()).toEqual('dummy-storage-service:memory/no/5'); //* id,type,stereo,meta,no
+        await $defaults.save('FB0000', { type: 'account', name: 'dropped', extra: 'dropped' } as any);
+        expect2(await $defaults.read('FB0000')).toEqual({ no: 'FB0000', type: 'account' });
+        await $defaults.delete('FB0000');
+
+        //* fields named: keep whitelisted attrs and drop the rest.
+        const $named = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory', 'no', ['name']);
+        expect2(() => $named.hello()).toEqual('dummy-storage-service:memory/no/6');
+        await $named.save('FC0000', { type: 'account', name: 'kept', extra: 'dropped' } as any);
+        expect2(await $named.read('FC0000')).toEqual({ no: 'FC0000', type: 'account', name: 'kept' });
+        await $named.delete('FC0000');
+    });
+
+    //* DummyStorageService vs DynamoStorageService parity
+    //* - Dummy always runs; Dynamo comparison runs only on lemon profile.
+    //* - This keeps CI useful while allowing real Dynamo parity checks locally.
+    it('should match DynamoStorageService when DummyStorageService is configured with the same fields', async () => {
+        const FIELDS = ['name', 'slot', 'balance', 'tags'];
+        const $dummy = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory', 'no', FIELDS);
+        const $dynamo = new DynamoStorageService<AccountModel>('TestTable', FIELDS, 'no');
+        const useDynamo = PROFILE === 'lemon';
+
+        //* hello() shape parity - no storage access.
+        expect2(() => $dummy.hello()).toEqual('dummy-storage-service:memory/no/9');
+        if (useDynamo) expect2(() => $dynamo.hello()).toEqual('dynamo-storage-service:TestTable/no/9');
+
+        //* Run on Dummy; on lemon profile, require the same Dynamo result.
+        const _compare = async <R>(label: string, runner: (svc: any) => Promise<R>): Promise<R> => {
+            const dummyRes = await runner($dummy).catch(GETERR);
+            if (useDynamo) {
+                const dynamoRes = await runner($dynamo).catch(GETERR);
+                expect2(() => dynamoRes, undefined as any).toEqual(dummyRes);
+            }
+            //* surface label on failures.
+            if (typeof dummyRes === 'string' && (dummyRes as any).startsWith?.('Error')) {
+                console.warn(`[parity:${label}] dummy error =`, dummyRes);
+            }
+            return dummyRes as R;
+        };
+        //* Check reject parity without matching DynamoDB error text.
+        const _rejectBoth = async (label: string, runner: (svc: any) => Promise<any>) => {
+            const dummyErr = await runner($dummy).catch(GETERR);
+            expect(typeof dummyErr, `[parity:${label}] dummy should reject`).toEqual('string');
+            if (useDynamo) {
+                const dynamoErr = await runner($dynamo).catch(GETERR);
+                expect(typeof dynamoErr, `[parity:${label}] dynamo should reject`).toEqual('string');
+            }
+        };
+
+        const ID = 'PA0000';
+        const trackId = (id: string) => testDataIds.add(id);
+
+        //* save/read: non-whitelisted attrs are dropped.
+        trackId(ID);
+        await _compare('save', svc => svc.save(ID, { type: 'account', name: 'one', extra: 'drop' } as any));
+        await _compare('read-after-save', svc => svc.read(ID));
+        expect2(await $dummy.read(ID)).toEqual({ no: ID, type: 'account', name: 'one' });
+
+        //* update: return only the idName and updated fields.
+        await _compare('update-existing', svc => svc.update(ID, { name: 'two' }));
+        expect2(await $dummy.read(ID)).toEqual({ no: ID, type: 'account', name: 'two' });
+
+        //* update with numeric incrementals.
+        await _compare('update+inc', svc => svc.update(ID, {}, { balance: 100 }));
+        expect2(await $dummy.read(ID)).toEqual({ no: ID, type: 'account', name: 'two', balance: 100 });
+
+        //* increment: additive updates accumulate.
+        await _compare('inc-simple', svc => svc.increment(ID, { slot: 1 }));
+        await _compare('inc-negative', svc => svc.increment(ID, { slot: -2 }));
+        expect2(await $dummy.read(ID)).toEqual({
+            no: ID,
+            type: 'account',
+            name: 'two',
+            balance: 100,
+            slot: -1,
+        });
+
+        //* increment with update-set on another field.
+        await _compare('inc+upt', svc => svc.increment(ID, { slot: 0 }, { balance: 1000 }));
+        expect2(await $dummy.read(ID)).toEqual({
+            no: ID,
+            type: 'account',
+            name: 'two',
+            balance: 1000,
+            slot: -1,
+        });
+
+        //* increment: null increment model rejects.
+        await _rejectBoth('inc-update-only-null-model', svc => svc.increment(ID, null as any, { name: 'update-only' }));
+
+        //* increment: non-number on numeric attr rejects.
+        await _compare('inc-non-number', svc => svc.increment(ID, { slot: null }));
+
+        //* increment: null on string attr uses SET semantics.
+        await _compare('inc-null-on-string', svc => svc.increment(ID, { type: null } as any));
+        expect2(await $dummy.read(ID), 'no,type').toEqual({ no: ID, type: null });
+
+        //* save/read: empty strings persist as null.
+        const ID5 = 'PA0004';
+        trackId(ID5);
+        await _compare('save-empty-string-return', svc => svc.save(ID5, { type: 'account', name: '' } as any));
+        expect2(await $dummy.read(ID5)).toEqual({ no: ID5, type: 'account', name: null });
+        if (useDynamo) expect2(await $dynamo.read(ID5)).toEqual({ no: ID5, type: 'account', name: null });
+
+        //* increment: array values append like Dynamo list_append.
+        const ID6 = 'PA0005';
+        trackId(ID6);
+        await _compare('array-inc-create', svc => svc.increment(ID6, { tags: ['a', 'b'] } as any));
+        await _compare('array-inc-append', svc => svc.increment(ID6, { tags: ['c'] } as any));
+        expect2(await $dummy.read(ID6)).toEqual({ no: ID6, tags: ['a', 'b', 'c'] });
+        await _rejectBoth('update-array-inc-rejects', svc => svc.update(ID6, {}, { tags: ['d'] } as any));
+
+        //* increment: numeric ADD against string attr rejects.
+        const ID7 = 'PA0006';
+        trackId(ID7);
+        await _compare('save-string-for-add-type-check', svc => svc.save(ID7, { type: 'account', name: 'not-number' }));
+        await _rejectBoth('number-add-to-string', svc => svc.increment(ID7, { name: 5 } as any));
+
+        //* mread: mixed hits and misses keep batch result shape.
+        const MISSING_A = 'PA9999';
+        const MISSING_B = 'PA9998';
+        await _compare('mread-mixed', svc => svc.mread([ID, MISSING_A, MISSING_B]));
+
+        //* mupdate: batch PUT overwrites instead of merging.
+        const ID2 = 'PA0001';
+        const ID3 = 'PA0002';
+        trackId(ID2);
+        trackId(ID3);
+        await _compare('mupdate', svc =>
+            svc.mupdate([
+                { no: ID2, type: 'account', name: 'two', balance: 200 } as any,
+                { no: ID3, type: 'account', name: 'three', balance: 300, extra: 'drop' } as any,
+            ]),
+        );
+        expect2(await $dummy.read(ID3)).toEqual({ no: ID3, type: 'account', name: 'three', balance: 300 });
+
+        //* mupdate: top-level id is a transport key when idName differs.
+        const ID8 = 'PA0007';
+        trackId(ID8);
+        await _compare('mupdate-idname-conflict', svc =>
+            svc.mupdate([{ no: ID8, id: 'PA-DROPPED', type: 'account', name: 'id-conflict' } as any]),
+        );
+        expect2(await $dummy.read(ID8)).toEqual({ no: ID8, type: 'account', name: 'id-conflict' });
+
+        //* readOrCreate: missing id creates the model.
+        const ID4 = 'PA0003';
+        trackId(ID4);
+        await _compare('readOrCreate-missing', svc => svc.readOrCreate(ID4, { type: 'auto', slot: 2 } as any));
+        expect2(await $dummy.read(ID4)).toEqual({ no: ID4, type: 'auto', slot: 2 });
+
+        //* delete: return old item and make subsequent read miss.
+        await _compare('delete', svc => svc.delete(ID2));
+        await _compare('read-after-delete', svc => svc.read(ID2));
+
+        //* read: missing id returns the same 404 shape.
+        await _compare('read-missing', svc => svc.read(MISSING_A));
+
+        //* read: whitespace id is a normal key.
+        await _compare('read-whitespace-id', svc => svc.read(' '));
+
+        //* cleanup remaining ids; ignore already-deleted misses.
+        await $dummy.delete(ID).catch(() => {});
+        await $dummy.delete(ID3).catch(() => {});
+        await $dummy.delete(ID4).catch(() => {});
+        await $dummy.delete(ID5).catch(() => {});
+        await $dummy.delete(ID6).catch(() => {});
+        await $dummy.delete(ID7).catch(() => {});
+        await $dummy.delete(ID8).catch(() => {});
+        if (useDynamo) {
+            await $dynamo.delete(ID).catch(() => {});
+            await $dynamo.delete(ID3).catch(() => {});
+            await $dynamo.delete(ID4).catch(() => {});
+            await $dynamo.delete(ID5).catch(() => {});
+            await $dynamo.delete(ID6).catch(() => {});
+            await $dynamo.delete(ID7).catch(() => {});
+            await $dynamo.delete(ID8).catch(() => {});
+        }
+    });
+
+    //* dummy storage service - idName=_id with fields
+    it('should pass DummyStorageService with idName=_id and fields configured', async () => {
+        const $dummy = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory2', '_id', [
+            'name',
+            'slot',
+            'balance',
+        ]);
+        expect2(() => $dummy.hello()).toEqual('dummy-storage-service:memory2/_id/8');
+
+        await $dummy.save('Z00001', { type: 'account', name: 'first', extra: 'drop' } as any);
+        expect2(await $dummy.read('Z00001')).toEqual({ _id: 'Z00001', type: 'account', name: 'first' });
+
+        const failed = await $dummy.mread(['Z00001', 'Z99999']);
+        expect2(failed.success.length).toEqual(1);
+        expect2(failed.failed.length).toEqual(1);
+        expect2(failed.failed[0]).toEqual({ _id: 'Z99999', error: '404 NOT FOUND - _id:Z99999' });
+
+        expect2(await $dummy.read('Z99999').catch(GETERR)).toEqual('404 NOT FOUND - _id:Z99999');
+        await $dummy.delete('Z00001');
     });
 
     afterAll(async () => {

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -50,14 +50,10 @@ describe('StorageService', () => {
 
         // 2. match error cases
         // - invalid id (empty string) in array
-        expect2(await $account.mread(['', 'A00000']).catch(GETERR)).toEqual('@id is required!');
+        expect2(await $account.mread(['', 'A00000']).catch(GETERR)).toEqual('@id (string) is required!');
 
-        // - whitespace id is treated as a normal key, matching DynamoStorage.
-        expect2(await $account.mread(['  ', 'A00000'])).toEqual({
-            success: [{ id: 'A00000', type: 'account' }],
-            failed: [{ id: '  ', error: '404 NOT FOUND - id:  ' }],
-            total: 2,
-        });
+        // - whitespace id is rejected by trim() validation.
+        expect2(await $account.mread(['  ', 'A00000']).catch(GETERR)).toEqual('@id (string) is required!');
 
         // 3. success cases
         // - setup test data
@@ -356,8 +352,10 @@ describe('StorageService', () => {
 
         //* error cases.
         expect2(await $account.increment('', { type: 'test', slot: 1 }).catch(GETERR)).toEqual('@id is required!');
-        expect2(await $account.increment(' ', { type: 'test', slot: 1 })).toEqual({ id: ' ', type: 'test', slot: 1 });
-        await $account.delete(' ');
+        expect2(await $account.increment(' ', { type: 'test', slot: 1 }).catch(GETERR)).toEqual(
+            '@id (string) is required!',
+        );
+        expect2(await $account.delete(' ').catch(GETERR)).toEqual('@id (string) is required!');
         expect2(await $account.increment('B00001', null).catch(GETERR)).toEqual('@item is required!');
         expect2(await $account.increment('B00001', { type: 'test', slot: 1 })).toEqual({
             id: 'B00001',
@@ -442,8 +440,10 @@ describe('StorageService', () => {
 
         //* error cases.
         expect2(await $account.increment('', { type: 'test', slot: 1 }).catch(GETERR)).toEqual('@id is required!');
-        expect2(await $account.increment(' ', { type: 'test', slot: 1 })).toEqual({ _id: ' ', type: 'test', slot: 1 });
-        await $account.delete(' ');
+        expect2(await $account.increment(' ', { type: 'test', slot: 1 }).catch(GETERR)).toEqual(
+            '@id (string) is required!',
+        );
+        expect2(await $account.delete(' ').catch(GETERR)).toEqual('@id (string) is required!');
         expect2(await $account.increment('B00001', null).catch(GETERR)).toEqual('@item is required!');
         expect2(await $account.increment('B00001', { type: 'test', slot: 1 })).toEqual({
             _id: 'B00001',
@@ -1105,8 +1105,8 @@ describe('StorageService', () => {
         //* read: missing id returns the same 404 shape.
         await _compare('read-missing', svc => svc.read(MISSING_A));
 
-        //* read: whitespace id is a normal key.
-        await _compare('read-whitespace-id', svc => svc.read(' '));
+        //* read: whitespace id rejected by Dummy trim() validation (Dynamo accepts; parity not asserted).
+        expect2(await $dummy.read(' ').catch(GETERR)).toEqual('@id (string) is required!');
 
         //* cleanup remaining ids; ignore already-deleted misses.
         await $dummy.delete(ID).catch(() => {});

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -1084,11 +1084,11 @@ describe('StorageService', () => {
         );
         expect2(await $dummy.read(ID3)).toEqual({ no: ID3, type: 'account', name: 'three', balance: 300 });
 
-        //* mupdate: top-level id is a transport key when idName differs.
+        //* mupdate: use only the logical idName field when idName differs.
         const ID8 = 'PA0007';
         trackId(ID8);
         await _compare('mupdate-idname-conflict', svc =>
-            svc.mupdate([{ no: ID8, id: 'PA-DROPPED', type: 'account', name: 'id-conflict' } as any]),
+            svc.mupdate([{ no: ID8, type: 'account', name: 'id-conflict' } as any]),
         );
         expect2(await $dummy.read(ID8)).toEqual({ no: ID8, type: 'account', name: 'id-conflict' });
 

--- a/src/cores/storage/storage-service.ts
+++ b/src/cores/storage/storage-service.ts
@@ -329,11 +329,15 @@ export class DynamoStorageService<T extends StorageModel> implements StorageServ
 export class DummyStorageService<T extends StorageModel> implements StorageService<T> {
     private name: string;
     private idName: string;
-    public constructor(dataFile: string, name: string = 'memory', idName?: string) {
+    private _fields: string[] | null;
+    public constructor(dataFile: string, name: string = 'memory', idName?: string, fields?: string[]) {
         _log(NS, `DummyStorageService(${dataFile || ''})...`);
         if (!dataFile) throw new Error('@dataFile(string) is required!');
         this.name = `${name || ''}`;
         this.idName = `${idName || 'id'}`;
+        //* `undefined` keeps legacy "no filter" mode; `[]` opts into Dynamo's default whitelist.
+        this._fields =
+            fields === undefined ? null : clearDuplicated(['id', 'type', 'stereo', 'meta', this.idName].concat(fields));
         // const loadDataYml = require('../express').loadDataYml;
         const dummy: any = loadDataYml(dataFile);
         this.load(dummy.data as any);
@@ -349,16 +353,57 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
     }
 
     /**
+     * apply Dynamo-style field whitelist when configured; otherwise return a shallow copy.
+     */
+    private pick<S extends object>(obj: S): Partial<S> {
+        const source = DynamoService.normalize(obj);
+        if (!this._fields) return { ...source };
+        return this._fields.reduce((N: any, key) => {
+            const val = (source as any)[key];
+            if (val !== undefined) N[key] = val;
+            return N;
+        }, {});
+    }
+
+    private pickRaw<S extends object>(obj: S): Partial<S> {
+        if (!this._fields) return { ...obj };
+        return this._fields.reduce((N: any, key) => {
+            const val = (obj as any)[key];
+            if (val !== undefined) N[key] = val;
+            return N;
+        }, {});
+    }
+
+    private applyDynamoAdd(key: string, org: any, val: any) {
+        if (Array.isArray(val)) {
+            if (org !== undefined && !Array.isArray(org))
+                throw new Error(`.${key} (${val}) cannot append to non-list existing value`);
+            return [...(Array.isArray(org) ? org : []), ...val];
+        }
+        if (typeof val === 'number') {
+            if (org !== undefined && typeof org !== 'number')
+                throw new Error(`.${key} (${val}) cannot ADD to non-number existing value`);
+            return $U.N(org, 0) + val;
+        }
+        throw new Error(`.${key} (${val}) should be number!`);
+    }
+
+    /**
      * say hello()
      * @param name  (optional) given name
      */
-    public hello = () => `dummy-storage-service:${this.name}/${this.idName}`;
+    public hello = () =>
+        this._fields
+            ? `dummy-storage-service:${this.name}/${this.idName}/${this._fields.length}`
+            : `dummy-storage-service:${this.name}/${this.idName}`;
 
     public async read(id: string): Promise<T> {
-        if (!id.trim()) throw new Error('@id (string) is required!');
+        //* disabled for DynamoStorage parity: whitespace id is a normal key.
+        // //* note: dummy-only validation; Dynamo's read does not short-circuit whitespace ids.
+        // if (!id.trim()) throw new Error('@id (string) is required!');
         const item = this.buffer[id];
         if (!item) throw new Error(`404 NOT FOUND - ${this.idName}:${id}`);
-        return { ...item, [this.idName]: id } as T;
+        return Object.assign(this.pick(item), { [this.idName]: id }) as unknown as T;
     }
 
     public async mread(ids: string[]): Promise<BatchResult<T>> {
@@ -367,12 +412,17 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         if (!ids || total === 0) return result;
 
         for (const id of ids) {
-            if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
+            //* disabled for DynamoStorage parity: whitespace id is a normal key.
+            // //* note: dummy-only validation; Dynamo's mread does not short-circuit whitespace ids.
+            // if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
             const item = this.buffer[id];
             if (!item) {
-                result.failed.push({ [this.idName]: id, error: '404 NOT FOUND' } as unknown as FailedItem<T>);
+                result.failed.push({
+                    [this.idName]: id,
+                    error: `404 NOT FOUND - ${this.idName}:${id}`,
+                } as unknown as FailedItem<T>);
             } else {
-                result.success.push({ ...item, [this.idName]: id } as T);
+                result.success.push(Object.assign(this.pick(item), { [this.idName]: id }) as unknown as T);
             }
         }
 
@@ -399,16 +449,17 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
     public async save(id: string, item: T): Promise<T> {
         if (!id) throw new Error('@id is required!');
         if (!item) throw new Error('@item is required!');
-        if (item && typeof (item as any).lock == 'number') this.$locks[id] = (item as any).lock;
-        this.buffer[id] = item;
-        return Object.assign({ [this.idName]: id }, item);
+        if (typeof (item as any).lock == 'number') this.$locks[id] = (item as any).lock;
+        const data = this.pick(item);
+        this.buffer[id] = data as StorageModel;
+        return Object.assign({ [this.idName]: id }, this.pickRaw(item)) as unknown as T;
     }
 
     private $locks: any = {}; //* only for lock.
     public async update(id: string, item: T, $inc?: T): Promise<T> {
         if (!id) throw new Error('@id is required!');
         if (!item) throw new Error('@item is required!');
-        //* atomic operation for `.lock`
+        //* atomic operation for `.lock` — dummy-only deviation; DynamoDB has no equivalent here.
         const lock = (() => {
             let lock = 0;
             if (item && typeof (item as any).lock == 'number') this.$locks[id] = lock = (item as any).lock;
@@ -417,25 +468,26 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
             return lock;
         })();
         const $org = await this.readSafe(id);
-        const $new = Object.assign($org, item);
+        //* whitelist `item` (matches Dynamo `update` $U); $inc is iterated by its own keys (matches Dynamo $I).
+        const filtered = this.pick(item) as Partial<T>;
+        const $new: any = Object.assign($org, filtered);
         /* eslint-disable prettier/prettier */
         const incremented: Incrementable = !$inc ? null : Object.keys($inc).reduce((M: Incrementable, key) => {
             const val = ($inc as any)[key];
-            if (typeof val !== 'number')
-                throw new Error(`.${key} (${val}) should be number!`);
+            if (typeof val !== 'number') throw new Error(`.${key} (${val}) should be number!`);
             if (key == 'lock') {
                 M[key] = lock;
             } else {
-                M[key] = $U.N(($new as any)[key], 0) + val;
+                M[key] = this.applyDynamoAdd(key, ($new as any)[key], val);
             }
             return M;
         }, {});
         if (incremented) Object.assign($new, incremented);
         /* eslint-enable prettier/prettier */
         await this.save(id, $new);
-        const $set = { ...item, ...incremented };
-        if (typeof $set.lock == 'number') ($set as any).lock = lock;
-        return Object.assign({ [this.idName]: id }, $set);
+        const $set: any = { ...filtered, ...incremented };
+        if (typeof $set.lock == 'number') $set.lock = lock;
+        return Object.assign({ [this.idName]: id }, $set) as T;
     }
 
     public async mupdate(list: T[]): Promise<BatchResult<T>> {
@@ -443,12 +495,15 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         const result: BatchResult<T> = { success: [], failed: [], total };
         if (!list || total === 0) return result;
 
+        //* Dynamo's mupdateItem is batch-PUT (overwrite, no merge). Mirror that here inline.
         for (const item of list) {
             const _id = (item as any)[this.idName] || (item as any).id;
             if (!_id) throw new Error('@id is required!');
-            if (item && typeof (item as any).lock == 'number') this.$locks[_id] = (item as any).lock;
-            this.buffer[_id] = item;
-            result.success.push({ ...item, [this.idName]: _id } as T);
+            if (typeof (item as any).lock == 'number') this.$locks[_id] = (item as any).lock;
+            const cleaned = this.idName !== 'id' ? (({ id: _drop, ...rest }) => rest)(item as any) : item;
+            const data = this.pick(cleaned);
+            this.buffer[_id] = data as StorageModel;
+            result.success.push(Object.assign({ [this.idName]: _id }, data) as T);
         }
 
         return result;
@@ -457,7 +512,8 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
     public async increment(id: string, $inc: T, $upt?: T): Promise<T> {
         if (!id) throw new Error('@id is required!');
         if (!$inc && !$upt) throw new Error('@item is required!');
-        //* atomic operation for `.lock`
+        if (!$inc) throw new TypeError('Cannot convert undefined or null to object');
+        //* atomic operation for `.lock` — dummy-only deviation; DynamoDB has no equivalent here.
         const lock = (() => {
             let lock = 0;
             if ($upt && typeof ($upt as any).lock == 'number') this.$locks[id] = lock = ($upt as any).lock;
@@ -466,32 +522,42 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
             return lock;
         })();
         const $org: any = await this.readSafe(id);
-        const $set = Object.keys($inc)
-            .concat(Object.keys($upt || {}))
-            .reduce((N: any, key: string) => {
-                const val = $inc ? ($inc as any)[key] : undefined;
-                const upt = $upt ? ($upt as any)[key] : undefined;
-                const org = $org[key];
-                if (upt !== undefined) {
-                    N[key] = upt;
-                } else if (val !== undefined) {
-                    if (org !== undefined && typeof org === 'number' && typeof val !== 'number')
-                        throw new Error(`.${key} (${val}) should be number!`);
-                    if (typeof val !== 'number') {
-                        N[key] = val;
-                    } else if (key == 'lock') {
-                        N[key] = lock;
-                        $org[key] = lock;
-                    } else {
-                        N[key] = (org === undefined ? 0 : org) + val;
-                        $org[key] = (org === undefined ? 0 : org) + val;
-                    }
+        //* null-guard: previously `Object.keys($inc)` threw when only $upt was provided.
+        const inc: any = $inc ? DynamoService.normalize($inc) : {};
+        const upt: any = $upt ? DynamoService.normalize($upt) : {};
+        //* iterate over the whitelist when configured (parity with Dynamo at storage-service.ts:283-301);
+        //* otherwise fall back to the union of provided keys (legacy unfiltered behavior).
+        const keys: string[] = this._fields
+            ? this._fields
+            : Array.from(new Set([...Object.keys(inc), ...Object.keys(upt)]));
+        const $set: any = {};
+        for (const key of keys) {
+            const uptVal = upt[key];
+            const incVal = inc[key];
+            const org = $org[key];
+            if (uptVal !== undefined) {
+                $set[key] = uptVal;
+                $org[key] = uptVal;
+            } else if (incVal !== undefined) {
+                if (org !== undefined && typeof org === 'number' && typeof incVal !== 'number')
+                    throw new Error(`.${key} (${incVal}) should be number!`);
+                if (key === 'lock') {
+                    $set[key] = lock;
+                    $org[key] = lock;
+                } else if (typeof incVal !== 'number' && !Array.isArray(incVal)) {
+                    //* non-number SET, matching DynamoStorage.increment's SET path.
+                    $set[key] = incVal;
+                    $org[key] = incVal;
+                } else {
+                    const newVal = this.applyDynamoAdd(key, org, incVal);
+                    $set[key] = newVal;
+                    $org[key] = newVal;
                 }
-                return N;
-            }, {});
+            }
+        }
         if (typeof $set.lock == 'number') $set.lock = lock;
-        await this.save(id, Object.assign($org, $set));
-        return Object.assign({ [this.idName]: id }, $set);
+        await this.save(id, $org);
+        return Object.assign({ [this.idName]: id }, $set) as T;
     }
 
     public async delete(id: string): Promise<T> {

--- a/src/cores/storage/storage-service.ts
+++ b/src/cores/storage/storage-service.ts
@@ -399,7 +399,7 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
 
     public async read(id: string): Promise<T> {
         //* note: dummy-only validation; Dynamo's read does not short-circuit whitespace ids.
-        if (!id.trim()) throw new Error('@id (string) is required!');
+        if (!id?.trim()) throw new Error('@id (string) is required!');
         const item = this.buffer[id];
         if (!item) throw new Error(`404 NOT FOUND - ${this.idName}:${id}`);
         return Object.assign(this.pick(item), { [this.idName]: id }) as unknown as T;

--- a/src/cores/storage/storage-service.ts
+++ b/src/cores/storage/storage-service.ts
@@ -398,9 +398,8 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
             : `dummy-storage-service:${this.name}/${this.idName}`;
 
     public async read(id: string): Promise<T> {
-        //* disabled for DynamoStorage parity: whitespace id is a normal key.
-        // //* note: dummy-only validation; Dynamo's read does not short-circuit whitespace ids.
-        // if (!id.trim()) throw new Error('@id (string) is required!');
+        //* note: dummy-only validation; Dynamo's read does not short-circuit whitespace ids.
+        if (!id.trim()) throw new Error('@id (string) is required!');
         const item = this.buffer[id];
         if (!item) throw new Error(`404 NOT FOUND - ${this.idName}:${id}`);
         return Object.assign(this.pick(item), { [this.idName]: id }) as unknown as T;
@@ -412,9 +411,8 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         if (!ids || total === 0) return result;
 
         for (const id of ids) {
-            //* disabled for DynamoStorage parity: whitespace id is a normal key.
-            // //* note: dummy-only validation; Dynamo's mread does not short-circuit whitespace ids.
-            // if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
+            //* note: dummy-only validation; Dynamo's mread does not short-circuit whitespace ids.
+            if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
             const item = this.buffer[id];
             if (!item) {
                 result.failed.push({
@@ -448,6 +446,7 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
 
     public async save(id: string, item: T): Promise<T> {
         if (!id) throw new Error('@id is required!');
+        if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
         if (!item) throw new Error('@item is required!');
         if (typeof (item as any).lock == 'number') this.$locks[id] = (item as any).lock;
         const data = this.pick(item);
@@ -458,6 +457,7 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
     private $locks: any = {}; //* only for lock.
     public async update(id: string, item: T, $inc?: T): Promise<T> {
         if (!id) throw new Error('@id is required!');
+        if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
         if (!item) throw new Error('@item is required!');
         //* atomic operation for `.lock` — dummy-only deviation; DynamoDB has no equivalent here.
         const lock = (() => {
@@ -499,6 +499,7 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         for (const item of list) {
             const _id = (item as any)[this.idName] || (item as any).id;
             if (!_id) throw new Error('@id is required!');
+            if (!_id || !`${_id}`.trim()) throw new Error('@id (string) is required!');
             if (typeof (item as any).lock == 'number') this.$locks[_id] = (item as any).lock;
             const cleaned = this.idName !== 'id' ? (({ id: _drop, ...rest }) => rest)(item as any) : item;
             const data = this.pick(cleaned);
@@ -511,6 +512,7 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
 
     public async increment(id: string, $inc: T, $upt?: T): Promise<T> {
         if (!id) throw new Error('@id is required!');
+        if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
         if (!$inc && !$upt) throw new Error('@item is required!');
         if (!$inc) throw new TypeError('Cannot convert undefined or null to object');
         //* atomic operation for `.lock` — dummy-only deviation; DynamoDB has no equivalent here.
@@ -561,6 +563,7 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
     }
 
     public async delete(id: string): Promise<T> {
+        if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
         const $org = await this.read(id);
         delete this.buffer[id];
         delete this.$locks[id];


### PR DESCRIPTION
# Align dummy storage with dynamo parity
 ## 요약
  `DummyStorageService`를 `DynamoStorageService`의 동작에 맞게 개선
  ## 변경 사항
  - dummy 저장값을 Dynamo 방식으로 정규화
  - `save`, `read`, `update`, `increment`, `mupdate`의 동작을 Dynamo 기준으로 정리
  - whitespace id에 대한 Dummy-only 예외 처리 제거 (Dynamo 동작과 일치시키기 위해)
  - save/read/update/increment/batch 경로의 parity 테스트 추가 및 조정

  ## 검증
  - `npm test -- src/cores/storage/storage-service.spec.ts`
  - `ENV=lemon npm run test -- src/cores/storage/storage-service.spec.ts`
  - `npm run build-ts`