### PR TITLE
Feat/opt storage increment

### DIFF
--- a/src/common/test-helper.spec.ts
+++ b/src/common/test-helper.spec.ts
@@ -9,7 +9,7 @@
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { vi, describe, it, expect } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { expect2, marshal, Filter, _it, environ, waited, GETERR, GETERR$, NUL404, asErrorPayload } from './test-helper';
 
 //! main test body.

--- a/src/controllers/dummy-controller.spec.ts
+++ b/src/controllers/dummy-controller.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import { LambdaWEBHandler, LambdaHandler, ProtocolParam } from '../cores';
 import { buildEngine } from '../engine';

--- a/src/controllers/dummy-controller.spec.ts
+++ b/src/controllers/dummy-controller.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import { LambdaWEBHandler, LambdaHandler, ProtocolParam } from '../cores';

--- a/src/controllers/general-api-controller.spec.ts
+++ b/src/controllers/general-api-controller.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { LambdaWEBHandler, LambdaHandler } from '../cores/lambda';
 import { ProtocolParam, Elastic6QueryService } from '../cores';
 import { buildEngine } from '../engine';

--- a/src/controllers/general-api-controller.spec.ts
+++ b/src/controllers/general-api-controller.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { LambdaWEBHandler, LambdaHandler } from '../cores/lambda';
 import { ProtocolParam, Elastic6QueryService } from '../cores';

--- a/src/controllers/general-controller.spec.ts
+++ b/src/controllers/general-controller.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import { LambdaWEBHandler, LambdaHandler } from '../cores/lambda';
 import { ProtocolParam, NextHandler } from '../cores';

--- a/src/controllers/general-controller.spec.ts
+++ b/src/controllers/general-controller.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import { LambdaWEBHandler, LambdaHandler } from '../cores/lambda';

--- a/src/cores/api/api-service.spec.ts
+++ b/src/cores/api/api-service.spec.ts
@@ -7,7 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { vi, describe, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import $engine, { $U } from '../../engine';
 import { GETERR, expect2 } from '../../common/test-helper';
 import { APIService, APIServiceClient, APIHeaders, ApiHttpProxy, MocksAPIService } from './api-service';

--- a/src/cores/api/api-service.spec.ts
+++ b/src/cores/api/api-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import $engine, { $U } from '../../engine';
 import { GETERR, expect2 } from '../../common/test-helper';

--- a/src/cores/aws/aws-kms-service.spec.ts
+++ b/src/cores/aws/aws-kms-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2, environ, GETERR } from '../../common/test-helper';
 import { $U } from '../../engine';
 import { loadProfile } from '../../environ';

--- a/src/cores/aws/aws-kms-service.spec.ts
+++ b/src/cores/aws/aws-kms-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2, environ, GETERR } from '../../common/test-helper';
 import { $U } from '../../engine';

--- a/src/cores/aws/aws-s3-service.spec.ts
+++ b/src/cores/aws/aws-s3-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 const ENV_NAME = 'MY_S3_BUCKET';
 const DEF_BUCKET = 'lemon-hello-www';
 

--- a/src/cores/aws/aws-s3-service.spec.ts
+++ b/src/cores/aws/aws-s3-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 const ENV_NAME = 'MY_S3_BUCKET';
 const DEF_BUCKET = 'lemon-hello-www';

--- a/src/cores/aws/aws-sns-service.spec.ts
+++ b/src/cores/aws/aws-sns-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 const ENV_NAME = 'MY_SNS_ENDPOINT';
 const DEF_SNS = 'lemon-hello-sns';

--- a/src/cores/aws/aws-sns-service.spec.ts
+++ b/src/cores/aws/aws-sns-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 const ENV_NAME = 'MY_SNS_ENDPOINT';
 const DEF_SNS = 'lemon-hello-sns';
 

--- a/src/cores/aws/aws-sqs-service.spec.ts
+++ b/src/cores/aws/aws-sqs-service.spec.ts
@@ -10,6 +10,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, GETERR, _it } from '../../common/test-helper';
 import { AWSSQSService, MyDummySQSService } from './aws-sqs-service';

--- a/src/cores/aws/aws-sqs-service.spec.ts
+++ b/src/cores/aws/aws-sqs-service.spec.ts
@@ -10,6 +10,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, GETERR, _it } from '../../common/test-helper';

--- a/src/cores/cache/cache-service.spec.ts
+++ b/src/cores/cache/cache-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import net from 'net';
 import { expect2, GETERR, _it } from '../..';

--- a/src/cores/cache/cache-service.spec.ts
+++ b/src/cores/cache/cache-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import net from 'net';
 import { expect2, GETERR, _it } from '../..';
 import { CacheService, DummyCacheService, sleep, toTTL, fromTTL } from './cache-service';

--- a/src/cores/config/config-service.spec.ts
+++ b/src/cores/config/config-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, GETERR } from '../../common/test-helper';
 import { $U } from '../../engine/';

--- a/src/cores/config/config-service.spec.ts
+++ b/src/cores/config/config-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, GETERR } from '../../common/test-helper';

--- a/src/cores/dynamo/dynamo-query-service.spec.ts
+++ b/src/cores/dynamo/dynamo-query-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2 } from '../../common/test-helper';

--- a/src/cores/dynamo/dynamo-query-service.spec.ts
+++ b/src/cores/dynamo/dynamo-query-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2 } from '../../common/test-helper';
 import { DynamoService, DynamoOption } from './dynamo-service';

--- a/src/cores/dynamo/dynamo-scan-service.spec.ts
+++ b/src/cores/dynamo/dynamo-scan-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, _it } from '../../common/test-helper';

--- a/src/cores/dynamo/dynamo-scan-service.spec.ts
+++ b/src/cores/dynamo/dynamo-scan-service.spec.ts
@@ -8,7 +8,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, _it } from '../../common/test-helper';
 import { loadDataYml } from '../../tools';

--- a/src/cores/dynamo/dynamo-service.spec.ts
+++ b/src/cores/dynamo/dynamo-service.spec.ts
@@ -175,6 +175,36 @@ describe('DynamoService', () => {
             expect2(await dummy.updateItem('A0', 0, { type: 'account' }).catch(GETERR), 'ID').toEqual({ ID: 'A0' });
             expect2(await dummy.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: 'account' });
 
+            //* updateItem with increments: number ADD and string[] append.
+            const ATOM_ID = 'A-ATOMIC';
+            await dummy.saveItem(ATOM_ID, { type: 'atomic', n: 0, s: [] } as any);
+
+            const inc = (increments: any) => dummy.updateItem(ATOM_ID, 0, {}, increments);
+            await Promise.all(Array.from({ length: 100 }, (_, i) => inc({ n: i + 1 })));
+            expect2(await dummy.readItem(ATOM_ID), 'ID,type,n').toEqual({ ID: ATOM_ID, type: 'atomic', n: 5050 });
+
+            await Promise.all('abcdefgh'.split('').map(s => inc({ s: [s] })));
+            const atom = (await dummy.readItem(ATOM_ID)) as any;
+            expect2(atom.s.sort().join('')).toEqual('abcdefgh');
+
+            const atom2 = (await dummy.updateItem(ATOM_ID, 0, { type: 'atomic-updated' }, {
+                n: 1,
+                s: ['z'],
+            } as any)) as any;
+            expect2(atom2, 'ID,type,n').toEqual({
+                ID: ATOM_ID,
+                type: 'atomic-updated',
+                n: 5051,
+            });
+            expect2([...atom2.s].sort().join('')).toEqual('abcdefghz');
+            expect2(atom2.type).toEqual('atomic-updated');
+            expect2(await dummy.readItem(ATOM_ID), 'ID,type,n').toEqual({
+                ID: ATOM_ID,
+                type: 'atomic-updated',
+                n: 5051,
+            });
+            await dummy.deleteItem(ATOM_ID);
+
             //* check dummy data list
             expect2(dummy.hello()).toEqual(`dummy-dynamo-service:${tableName}`);
             expect2(await dummy.listItems(), '!list').toEqual({ page: 1, limit: 2, total: 3 });
@@ -784,6 +814,30 @@ describe('DynamoService', () => {
                     ID: 'A0',
                 });
                 expect2(await service.readItem('A0').catch(GETERR), 'ID,type').toEqual({ ID: 'A0', type: 'account' });
+
+                //* updateItem with increments: number ADD and string[] append.
+                const ATOM_ID = 'A-ATOMIC-REAL';
+                await service.saveItem(ATOM_ID, { type: 'atomic', n: 0, s: [] } as any);
+                dataMap.set(ATOM_ID, { ID: ATOM_ID } as MyModel);
+
+                const inc = (increments: any) => service.updateItem(ATOM_ID, 0, {}, increments);
+                await Promise.all(Array.from({ length: 100 }, (_, i) => inc({ n: i + 1 })));
+                expect2(await service.readItem(ATOM_ID), 'ID,type,n').toEqual({ ID: ATOM_ID, type: 'atomic', n: 5050 });
+
+                await Promise.all('abcdefgh'.split('').map(s => inc({ s: [s] })));
+                const atom = (await service.readItem(ATOM_ID)) as any;
+                expect2([...atom.s].sort().join('')).toEqual('abcdefgh');
+
+                const atom2 = (await service.updateItem(ATOM_ID, 0, { type: 'atomic-updated' }, {
+                    n: 1,
+                    s: ['z'],
+                } as any)) as any;
+                expect2(atom2, 'ID,type,n').toEqual({
+                    ID: ATOM_ID,
+                    type: 'atomic-updated',
+                    n: 5051,
+                });
+                expect2([...atom2.s].sort().join('')).toEqual('abcdefghz');
             }
 
             //* msaveItem test

--- a/src/cores/dynamo/dynamo-service.spec.ts
+++ b/src/cores/dynamo/dynamo-service.spec.ts
@@ -8,7 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2, _it } from '../../common/test-helper';
 import { loadDataYml } from '../../tools/';

--- a/src/cores/dynamo/dynamo-service.spec.ts
+++ b/src/cores/dynamo/dynamo-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2, _it } from '../../common/test-helper';

--- a/src/cores/dynamo/dynamo-service.ts
+++ b/src/cores/dynamo/dynamo-service.ts
@@ -1060,7 +1060,20 @@ export class DummyDynamoService<T extends GeneralItem> extends DynamoService<T> 
         const { idName } = this.options;
         const item = this.buffer[id];
         if (item === undefined) throw new Error(`404 NOT FOUND - ${idName}:${id}`);
-        this.buffer[id] = { ...item, ...normalize(updates) } as T;
+        const updated = { ...item, ...normalize(updates) } as any;
+        const incremented = Object.entries(increments || {}).reduce((memo: any, [key, value]) => {
+            const org = updated[key];
+            if (Array.isArray(value)) {
+                if (org !== undefined && !Array.isArray(org)) throw new Error(`.${key} (${value}) should be array!`);
+                memo[key] = [...(org || []), ...normalize(value)];
+            } else {
+                if (org !== undefined && typeof org !== 'number') throw new Error(`.${key} (${value}) should be number!`);
+                memo[key] = $U.N(org, 0) + (value as number);
+            }
+            updated[key] = memo[key];
+            return memo;
+        }, {});
+        this.buffer[id] = updated as T;
         return { [idName]: id, ...this.buffer[id] };
     }
 

--- a/src/cores/dynamo/tools/dynamo.spec.ts
+++ b/src/cores/dynamo/tools/dynamo.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2025 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../../../common/test-helper';
 import { strToBin } from './utils';
 import Serializer from './serializer';

--- a/src/cores/dynamo/tools/dynamo.spec.ts
+++ b/src/cores/dynamo/tools/dynamo.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2025 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../../../common/test-helper';
 import { strToBin } from './utils';

--- a/src/cores/elastic/elastic6-query-service.spec.ts
+++ b/src/cores/elastic/elastic6-query-service.spec.ts
@@ -8,7 +8,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2, waited } from '../..';
 import { Elastic6QueryService } from './elastic6-query-service';

--- a/src/cores/elastic/elastic6-query-service.spec.ts
+++ b/src/cores/elastic/elastic6-query-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2, waited } from '../..';

--- a/src/cores/elastic/elastic6-service.spec.ts
+++ b/src/cores/elastic/elastic6-service.spec.ts
@@ -10,7 +10,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { GETERR, expect2, _it, waited, loadJsonSync } from '../..';
 import { GeneralItem, Incrementable, SearchBody } from 'lemon-model';
 import { Elastic6Service, DummyElastic6Service, Elastic6Option, $ERROR, Elastic6Item } from './elastic6-service';

--- a/src/cores/elastic/elastic6-service.spec.ts
+++ b/src/cores/elastic/elastic6-service.spec.ts
@@ -10,6 +10,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { GETERR, expect2, _it, waited, loadJsonSync } from '../..';
 import { GeneralItem, Incrementable, SearchBody } from 'lemon-model';

--- a/src/cores/elastic/hangul-service.spec.ts
+++ b/src/cores/elastic/hangul-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../..';
 import { HangulService } from './hangul-service';
 

--- a/src/cores/elastic/hangul-service.spec.ts
+++ b/src/cores/elastic/hangul-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../..';
 import { HangulService } from './hangul-service';

--- a/src/cores/lambda/lambda-alb-handler.spec.ts
+++ b/src/cores/lambda/lambda-alb-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2025 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { NextContext } from 'lemon-model';
 import { expect2, GETERR$ } from '../../common/test-helper';

--- a/src/cores/lambda/lambda-alb-handler.spec.ts
+++ b/src/cores/lambda/lambda-alb-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2025 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { NextContext } from 'lemon-model';
 import { expect2, GETERR$ } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';

--- a/src/cores/lambda/lambda-cron-handler.spec.ts
+++ b/src/cores/lambda/lambda-cron-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';

--- a/src/cores/lambda/lambda-cron-handler.spec.ts
+++ b/src/cores/lambda/lambda-cron-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';
 import { LambdaCronHandler } from './lambda-cron-handler';

--- a/src/cores/lambda/lambda-dynamo-stream-handler.spec.ts
+++ b/src/cores/lambda/lambda-dynamo-stream-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2, GETERR } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';
 import { LambdaHandler } from './lambda-handler';

--- a/src/cores/lambda/lambda-dynamo-stream-handler.spec.ts
+++ b/src/cores/lambda/lambda-dynamo-stream-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2, GETERR } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';

--- a/src/cores/lambda/lambda-handler.spec.ts
+++ b/src/cores/lambda/lambda-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2, GETERR$ } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';
 import { LambdaHandler } from './lambda-handler';

--- a/src/cores/lambda/lambda-handler.spec.ts
+++ b/src/cores/lambda/lambda-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2, GETERR$ } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';

--- a/src/cores/lambda/lambda-notification-handler.spec.ts
+++ b/src/cores/lambda/lambda-notification-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';

--- a/src/cores/lambda/lambda-notification-handler.spec.ts
+++ b/src/cores/lambda/lambda-notification-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';
 import { LambdaHandler } from './lambda-handler';

--- a/src/cores/lambda/lambda-sns-handler.spec.ts
+++ b/src/cores/lambda/lambda-sns-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { $U } from '../../engine';
 import { expect2 } from '../../common/test-helper';

--- a/src/cores/lambda/lambda-sns-handler.spec.ts
+++ b/src/cores/lambda/lambda-sns-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { $U } from '../../engine';
 import { expect2 } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';

--- a/src/cores/lambda/lambda-sqs-handler.spec.ts
+++ b/src/cores/lambda/lambda-sqs-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { $U } from '../../engine';
 import { expect2 } from '../../common/test-helper';

--- a/src/cores/lambda/lambda-sqs-handler.spec.ts
+++ b/src/cores/lambda/lambda-sqs-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { $U } from '../../engine';
 import { expect2 } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/tools';

--- a/src/cores/lambda/lambda-web-handler.spec.ts
+++ b/src/cores/lambda/lambda-web-handler.spec.ts
@@ -8,18 +8,14 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { $U } from '../../engine/';
 import { NextDecoder, NextHandler, NextContext } from 'lemon-model';
 import { expect2, GETERR, GETERR$ } from '../../common/test-helper';
 import { loadJsonSync } from '../../tools/';
 import { ProtocolParam } from './../core-services';
-import {
-    LambdaWEBHandler,
-    CoreWEBController,
-    MyHttpHeaderTool,
-    buildResponse,
-} from './lambda-web-handler';
+import { LambdaWEBHandler, CoreWEBController, MyHttpHeaderTool, buildResponse } from './lambda-web-handler';
 import { LambdaHandler } from './lambda-handler';
 import * as $lambda from './lambda-handler.spec';
 import { NextIdentity } from '..';

--- a/src/cores/lambda/lambda-web-handler.spec.ts
+++ b/src/cores/lambda/lambda-web-handler.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { $U } from '../../engine/';

--- a/src/cores/protocol/protocol-service.spec.ts
+++ b/src/cores/protocol/protocol-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, GETERR } from '../../common/test-helper';
 import { NextContext } from 'lemon-model';

--- a/src/cores/protocol/protocol-service.spec.ts
+++ b/src/cores/protocol/protocol-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { expect2, GETERR } from '../../common/test-helper';

--- a/src/cores/storage/model-manager.spec.ts
+++ b/src/cores/storage/model-manager.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { CoreModel } from 'lemon-model';
 import {
     CoreModelFilterable,

--- a/src/cores/storage/model-manager.spec.ts
+++ b/src/cores/storage/model-manager.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { CoreModel } from 'lemon-model';
 import {

--- a/src/cores/storage/proxy-storage-service.spec.ts
+++ b/src/cores/storage/proxy-storage-service.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { CoreModel, CORE_FIELDS } from 'lemon-model';

--- a/src/cores/storage/proxy-storage-service.spec.ts
+++ b/src/cores/storage/proxy-storage-service.spec.ts
@@ -8,7 +8,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { CoreModel, CORE_FIELDS } from 'lemon-model';
 import { $U, do_parrallel } from '../../engine';

--- a/src/cores/storage/redis-storage-service.spec.ts
+++ b/src/cores/storage/redis-storage-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2, GETERR } from '../..';
 import { StorageModel } from './storage-service';

--- a/src/cores/storage/redis-storage-service.spec.ts
+++ b/src/cores/storage/redis-storage-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2, GETERR } from '../..';
 import { StorageModel } from './storage-service';
 import { RedisStorageService, DummyRedisStorageService } from './redis-storage-service';

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -7,7 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2 } from '../../common/test-helper';
 import { DynamoStorageService, DummyStorageService, StorageModel } from './storage-service';

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -1248,6 +1248,73 @@ describe('StorageService', () => {
             tags: ['seed', 'inc'],
         });
 
+        //* null/object/empty-array values are handled by shape in the same increment API.
+        const T5 = 'TI0005';
+        testDataIds.add(T5);
+        await _compare('typed-inc-shape-seed', svc =>
+            svc.save(T5, {
+                type: 'account',
+                name: 'seed',
+                slot: 10,
+                balance: 5,
+                tags: ['root'],
+                meta: { origin: true },
+            } as any),
+        );
+        expect2(
+            await _compare('typed-inc-shape-mixed', svc =>
+                svc.increment(
+                    T5,
+                    {
+                        name: '',
+                        slot: -3,
+                        balance: 0,
+                        tags: [],
+                        meta: { nested: { ok: true }, step: 1 },
+                    } as any,
+                    { stereo: 'from-update' } as any,
+                ),
+            ),
+        ).toEqual({
+            no: T5,
+            name: null,
+            slot: 7,
+            balance: 5,
+            tags: ['root'],
+            meta: { nested: { ok: true }, step: 1 },
+            stereo: 'from-update',
+        });
+        await _readBoth(T5, {
+            no: T5,
+            type: 'account',
+            name: null,
+            slot: 7,
+            balance: 5,
+            tags: ['root'],
+            meta: { nested: { ok: true }, step: 1 },
+            stereo: 'from-update',
+        });
+        expect2(
+            await _compare('typed-inc-shape-null-object', svc =>
+                svc.increment(T5, { name: 'restored', meta: null, tags: ['tail'] } as any),
+            ),
+        ).toEqual({
+            no: T5,
+            name: 'restored',
+            tags: ['root', 'tail'],
+            meta: null,
+        });
+        await _readBoth(T5, {
+            no: T5,
+            type: 'account',
+            name: 'restored',
+            slot: 7,
+            balance: 5,
+            tags: ['root', 'tail'],
+            meta: null,
+            stereo: 'from-update',
+        });
+
         //* type mismatch.
         const T3 = 'TI0003';
         testDataIds.add(T3);
@@ -1277,16 +1344,26 @@ describe('StorageService', () => {
         );
         await _readBoth(T3, { no: T3, type: 'account', name: 'foo', slot: 1, tags: ['a'] });
 
+        //* failed shape checks must not commit earlier valid fields from the same call.
+        await _rejectBoth(
+            'reject-keeps-state',
+            svc => svc.increment(T3, { balance: 5, tags: 'bad' } as any),
+            '.tags (bad) should be array!',
+        );
+        await _readBoth(T3, { no: T3, type: 'account', name: 'foo', slot: 1, tags: ['a'] });
+
         //* cleanup
         await $dummy.delete(T1).catch(() => {});
         await $dummy.delete(T2).catch(() => {});
         await $dummy.delete(T3).catch(() => {});
         await $dummy.delete(T4).catch(() => {});
+        await $dummy.delete(T5).catch(() => {});
         if (useDynamo) {
             await $dynamo.delete(T1).catch(() => {});
             await $dynamo.delete(T2).catch(() => {});
             await $dynamo.delete(T3).catch(() => {});
             await $dynamo.delete(T4).catch(() => {});
+            await $dynamo.delete(T5).catch(() => {});
         }
     });
 
@@ -1296,6 +1373,23 @@ describe('StorageService', () => {
         const $dummy = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory', 'no', FIELDS);
         const $dynamo = new DynamoStorageService<AccountModel>('TestTable', FIELDS, 'no');
         const useDynamo = PROFILE === 'lemon';
+
+        const expectMixedAtomicResult = (node: any, id: string, size: number) => {
+            expect2(node.no).toEqual(id);
+            expect2(node.type).toEqual('account');
+            expect2(node.slot).toEqual(size);
+            expect2(node.balance).toEqual(size * 2);
+            expect2(node.tags.length).toEqual(size);
+            expect2(new Set(node.tags).size).toEqual(size);
+            expect2([...node.tags].sort()).toEqual(Array.from({ length: size }, (_, i) => `tag-${i}`).sort());
+            expect(node.name, 'final string overwrite should be one complete concurrent value').toMatch(
+                /^inc-name-\d+$/,
+            );
+            expect2(node.meta?.kind).toEqual('inc');
+            expect(typeof node.meta?.index).toEqual('number');
+            expect(node.meta.index).toBeGreaterThanOrEqual(0);
+            expect(node.meta.index).toBeLessThan(size);
+        };
 
         //* number add.
         const A_DUMMY = 'AT0001';
@@ -1355,6 +1449,99 @@ describe('StorageService', () => {
             expect2(dynB.tags.length).toEqual(100);
             expect2(new Set(dynB.tags).size).toEqual(100);
             await $dynamo.delete(B_DYN).catch(() => {});
+        }
+
+        //* increment() must remain atomic when number/string/array/object parameters are mixed.
+        const MIXED_DUMMY = 'AT0005';
+        const mixedSize = 80;
+        await $dummy.save(MIXED_DUMMY, {
+            type: 'account',
+            name: 'seed',
+            slot: 0,
+            balance: 0,
+            tags: [],
+            meta: { kind: 'seed' },
+        } as any);
+        await Promise.all(
+            Array.from({ length: mixedSize }, (_, i) =>
+                $dummy.increment(MIXED_DUMMY, {
+                    name: `inc-name-${i}`,
+                    slot: 1,
+                    balance: 2,
+                    tags: [`tag-${i}`],
+                    meta: { kind: 'inc', index: i },
+                } as any),
+            ),
+        );
+        expectMixedAtomicResult(await $dummy.read(MIXED_DUMMY), MIXED_DUMMY, mixedSize);
+        await $dummy.delete(MIXED_DUMMY).catch(() => {});
+
+        //* update(..., increments) and increment(...) share atomicity for numeric adds while strings/objects overwrite.
+        const MIXED_UPDATE_DUMMY = 'AT0006';
+        await $dummy.save(MIXED_UPDATE_DUMMY, {
+            type: 'account',
+            name: 'seed',
+            slot: 0,
+            balance: 0,
+            tags: [],
+            meta: { kind: 'seed' },
+        } as any);
+        await Promise.all(
+            Array.from({ length: mixedSize }, (_, i) =>
+                i % 2 === 0
+                    ? $dummy.increment(MIXED_UPDATE_DUMMY, {
+                          name: `inc-name-${i}`,
+                          slot: 1,
+                          balance: 2,
+                          tags: [`tag-${i}`],
+                          meta: { kind: 'inc', index: i },
+                      } as any)
+                    : $dummy.update(
+                          MIXED_UPDATE_DUMMY,
+                          { name: `update-name-${i}`, meta: { kind: 'update', index: i } } as any,
+                          { slot: 1, balance: 2 } as any,
+                      ),
+            ),
+        );
+        const mixedUpdateDummy: any = await $dummy.read(MIXED_UPDATE_DUMMY);
+        expect2(mixedUpdateDummy.no).toEqual(MIXED_UPDATE_DUMMY);
+        expect2(mixedUpdateDummy.type).toEqual('account');
+        expect2(mixedUpdateDummy.slot).toEqual(mixedSize);
+        expect2(mixedUpdateDummy.balance).toEqual(mixedSize * 2);
+        expect2(mixedUpdateDummy.tags.length).toEqual(mixedSize / 2);
+        expect2(new Set(mixedUpdateDummy.tags).size).toEqual(mixedSize / 2);
+        expect2([...mixedUpdateDummy.tags].sort()).toEqual(
+            Array.from({ length: mixedSize / 2 }, (_, i) => `tag-${i * 2}`).sort(),
+        );
+        expect(mixedUpdateDummy.name).toMatch(/^(inc|update)-name-\d+$/);
+        expect(['inc', 'update']).toContain(mixedUpdateDummy.meta?.kind);
+        expect(typeof mixedUpdateDummy.meta?.index).toEqual('number');
+        await $dummy.delete(MIXED_UPDATE_DUMMY).catch(() => {});
+
+        if (useDynamo) {
+            const MIXED_DYN = 'AT0005D';
+            testDataIds.add(MIXED_DYN);
+            await $dynamo.save(MIXED_DYN, {
+                type: 'account',
+                name: 'seed',
+                slot: 0,
+                balance: 0,
+                tags: [],
+                meta: { kind: 'seed' },
+            } as any);
+            await Promise.all(
+                Array.from({ length: mixedSize }, (_, i) =>
+                    $dynamo.increment(MIXED_DYN, {
+                        name: `inc-name-${i}`,
+                        slot: 1,
+                        balance: 2,
+                        tags: [`tag-${i}`],
+                        meta: { kind: 'inc', index: i },
+                    } as any),
+                ),
+            );
+            expectMixedAtomicResult(await $dynamo.read(MIXED_DYN), MIXED_DYN, mixedSize);
+            await $dynamo.delete(MIXED_DYN).catch(() => {});
         }
     }, 60_000);
 

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2 } from '../../common/test-helper';

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -1436,6 +1436,14 @@ describe('StorageService', () => {
         expect2(new Set(dummyB.tags).size).toEqual(100);
         await $dummy.delete(B_DUMMY).catch(() => {});
 
+        //* string[] append with exact membership.
+        const C_DUMMY = 'AT0007';
+        const elements = 'abcdefghijklmnopqrstuvwxyz';
+        await Promise.all(elements.split('').map(s => $dummy.increment(C_DUMMY, { tags: [s] } as any)));
+        const dummyC: any = await $dummy.read(C_DUMMY);
+        expect2(dummyC.tags.sort().join('')).toEqual(elements);
+        await $dummy.delete(C_DUMMY).catch(() => {});
+
         if (useDynamo) {
             const B_DYN = 'AT0002D';
             testDataIds.add(B_DYN);
@@ -1449,6 +1457,13 @@ describe('StorageService', () => {
             expect2(dynB.tags.length).toEqual(100);
             expect2(new Set(dynB.tags).size).toEqual(100);
             await $dynamo.delete(B_DYN).catch(() => {});
+
+            const C_DYN = 'AT0007D';
+            testDataIds.add(C_DYN);
+            await Promise.all(elements.split('').map(s => $dynamo.increment(C_DYN, { tags: [s] } as any)));
+            const dynC: any = await $dynamo.read(C_DYN);
+            expect2(dynC.tags.sort().join('')).toEqual(elements);
+            await $dynamo.delete(C_DYN).catch(() => {});
         }
 
         //* increment() must remain atomic when number/string/array/object parameters are mixed.

--- a/src/cores/storage/storage-service.spec.ts
+++ b/src/cores/storage/storage-service.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2019 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it } from 'vitest';
 import { loadProfile } from '../../environ';
 import { GETERR, expect2 } from '../../common/test-helper';
 import { DynamoStorageService, DummyStorageService, StorageModel } from './storage-service';
@@ -1147,6 +1148,215 @@ describe('StorageService', () => {
         expect2(await $dummy.read('Z99999').catch(GETERR)).toEqual('404 NOT FOUND - _id:Z99999');
         await $dummy.delete('Z00001');
     });
+
+    //* array increment and string overwrite.
+    it('should support shape-driven array increment while keeping string overwrite', async () => {
+        const FIELDS = ['name', 'slot', 'balance', 'tags'];
+        const $dummy = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory', 'no', FIELDS);
+        const $dynamo = new DynamoStorageService<AccountModel>('TestTable', FIELDS, 'no');
+        const useDynamo = PROFILE === 'lemon';
+
+        const _compare = async <R>(_label: string, runner: (svc: any) => Promise<R>): Promise<R> => {
+            const dummyRes = await runner($dummy).catch(GETERR);
+            if (useDynamo) {
+                const dynamoRes = await runner($dynamo).catch(GETERR);
+                expect2(() => dynamoRes, undefined as any).toEqual(dummyRes);
+            }
+            return dummyRes as R;
+        };
+        const _readBoth = async (id: string, expected: any) => {
+            expect2(await $dummy.read(id)).toEqual(expected);
+            if (useDynamo) expect2(await $dynamo.read(id)).toEqual(expected);
+        };
+        const _rejectBoth = async (label: string, runner: (svc: any) => Promise<any>, expectedDummy: string) => {
+            const dummyErr = await runner($dummy).catch(GETERR);
+            expect2(dummyErr).toEqual(expectedDummy);
+            if (useDynamo) {
+                const dynamoErr = await runner($dynamo).catch(GETERR);
+                expect(typeof dynamoErr, `[shape-inc:${label}] dynamo should reject`).toEqual('string');
+            }
+        };
+
+        //* create by increment.
+        const T1 = 'TI0001';
+        testDataIds.add(T1);
+        expect2(
+            await _compare('typed-inc-initial', svc =>
+                svc.increment(T1, { name: 'a', slot: 1, tags: ['a', 'b'], extra: 'drop' } as any),
+            ),
+        ).toEqual({ no: T1, name: 'a', slot: 1, tags: ['a', 'b'] });
+        await _readBoth(T1, { no: T1, name: 'a', slot: 1, tags: ['a', 'b'] });
+
+        //* append arrays, add numbers, and overwrite strings in one increment call.
+        const T2 = 'TI0002';
+        testDataIds.add(T2);
+        await _compare('typed-inc-seed', svc =>
+            svc.save(T2, { type: 'account', name: 'b', slot: 7, balance: 100, tags: ['x'] } as any),
+        );
+        expect2(
+            await _compare('typed-inc-append', svc =>
+                svc.increment(T2, { name: 'a', slot: 3, balance: -25, tags: ['a', 'b'], extra: 'drop' } as any),
+            ),
+        ).toEqual({ no: T2, name: 'a', slot: 10, balance: 75, tags: ['x', 'a', 'b'] });
+        await _readBoth(T2, {
+            no: T2,
+            type: 'account',
+            name: 'a',
+            slot: 10,
+            balance: 75,
+            tags: ['x', 'a', 'b'],
+        });
+        expect2(
+            await _compare('typed-inc-append-again', svc => svc.increment(T2, { name: 'c', tags: ['c'] } as any)),
+        ).toEqual({
+            no: T2,
+            name: 'c',
+            tags: ['x', 'a', 'b', 'c'],
+        });
+        await _readBoth(T2, {
+            no: T2,
+            type: 'account',
+            name: 'c',
+            slot: 10,
+            balance: 75,
+            tags: ['x', 'a', 'b', 'c'],
+        });
+
+        //* $update can be combined with shape-driven increment on different fields.
+        const T4 = 'TI0004';
+        testDataIds.add(T4);
+        await _compare('typed-inc-update-seed', svc =>
+            svc.save(T4, { type: 'account', name: 'old', slot: 1, tags: ['seed'] } as any),
+        );
+        expect2(
+            await _compare('typed-inc-with-update', svc =>
+                svc.increment(
+                    T4,
+                    { name: 'inc-name', slot: 4, tags: ['inc'] } as any,
+                    {
+                        balance: 50,
+                    } as any,
+                ),
+            ),
+        ).toEqual({ no: T4, name: 'inc-name', slot: 5, balance: 50, tags: ['seed', 'inc'] });
+        await _readBoth(T4, {
+            no: T4,
+            type: 'account',
+            name: 'inc-name',
+            slot: 5,
+            balance: 50,
+            tags: ['seed', 'inc'],
+        });
+
+        //* type mismatch.
+        const T3 = 'TI0003';
+        testDataIds.add(T3);
+        await $dummy.save(T3, { type: 'account', name: 'foo', slot: 1, tags: ['a'] } as any);
+        if (useDynamo) await $dynamo.save(T3, { type: 'account', name: 'foo', slot: 1, tags: ['a'] } as any);
+
+        await _rejectBoth(
+            'number-field-string',
+            svc => svc.increment(T3, { slot: 'x' } as any),
+            '.slot (x) should be number!',
+        );
+        await _readBoth(T3, { no: T3, type: 'account', name: 'foo', slot: 1, tags: ['a'] });
+        await _rejectBoth(
+            'string-field-number',
+            svc => svc.increment(T3, { name: 1 } as any),
+            '.name (1) should be string!',
+        );
+        await _rejectBoth(
+            'array-field-string',
+            svc => svc.increment(T3, { tags: 'b' } as any),
+            '.tags (b) should be array!',
+        );
+        await _rejectBoth(
+            'string-field-array',
+            svc => svc.increment(T3, { name: ['x'] } as any),
+            '.name (x) should be string!',
+        );
+        await _readBoth(T3, { no: T3, type: 'account', name: 'foo', slot: 1, tags: ['a'] });
+
+        //* cleanup
+        await $dummy.delete(T1).catch(() => {});
+        await $dummy.delete(T2).catch(() => {});
+        await $dummy.delete(T3).catch(() => {});
+        await $dummy.delete(T4).catch(() => {});
+        if (useDynamo) {
+            await $dynamo.delete(T1).catch(() => {});
+            await $dynamo.delete(T2).catch(() => {});
+            await $dynamo.delete(T3).catch(() => {});
+            await $dynamo.delete(T4).catch(() => {});
+        }
+    });
+
+    //* atomic additive operations with Promise.all.
+    it('should preserve additive increment results under Promise.all concurrency', async () => {
+        const FIELDS = ['name', 'slot', 'balance', 'tags'];
+        const $dummy = new DummyStorageService<AccountModel>('ticketing-dummy-data', 'memory', 'no', FIELDS);
+        const $dynamo = new DynamoStorageService<AccountModel>('TestTable', FIELDS, 'no');
+        const useDynamo = PROFILE === 'lemon';
+
+        //* number add.
+        const A_DUMMY = 'AT0001';
+        await Promise.all(Array.from({ length: 100 }, (_, i) => $dummy.increment(A_DUMMY, { slot: i + 1 } as any)));
+        expect2((await $dummy.read(A_DUMMY)).slot).toEqual(5050);
+        await $dummy.delete(A_DUMMY).catch(() => {});
+
+        if (useDynamo) {
+            const A_DYN = 'AT0001D';
+            testDataIds.add(A_DYN);
+            await Promise.all(Array.from({ length: 100 }, (_, i) => $dynamo.increment(A_DYN, { slot: i + 1 } as any)));
+            expect2((await $dynamo.read(A_DYN)).slot).toEqual(5050);
+            await $dynamo.delete(A_DYN).catch(() => {});
+        }
+
+        //* update(..., increments) shares the same per-id queue in Dummy.
+        const U_DUMMY = 'AT0003';
+        await Promise.all(Array.from({ length: 100 }, (_, i) => $dummy.update(U_DUMMY, {}, { slot: i + 1 } as any)));
+        expect2((await $dummy.read(U_DUMMY)).slot).toEqual(5050);
+        await $dummy.delete(U_DUMMY).catch(() => {});
+
+        //* update(..., increments) and increment(...) should not lose additive writes when interleaved.
+        const MIX_DUMMY = 'AT0004';
+        await Promise.all(
+            Array.from({ length: 100 }, (_, i) =>
+                i % 2 === 0
+                    ? $dummy.increment(MIX_DUMMY, { slot: i + 1 } as any)
+                    : $dummy.update(MIX_DUMMY, {}, { slot: i + 1 } as any),
+            ),
+        );
+        expect2((await $dummy.read(MIX_DUMMY)).slot).toEqual(5050);
+        await $dummy.delete(MIX_DUMMY).catch(() => {});
+
+        //* number add with array append.
+        const B_DUMMY = 'AT0002';
+        await Promise.all(
+            Array.from({ length: 100 }, (_, i) =>
+                $dummy.increment(B_DUMMY, { slot: i + 1, tags: [`${i + 1}`] } as any),
+            ),
+        );
+        const dummyB: any = await $dummy.read(B_DUMMY);
+        expect2(dummyB.slot).toEqual(5050);
+        expect2(dummyB.tags.length).toEqual(100);
+        expect2(new Set(dummyB.tags).size).toEqual(100);
+        await $dummy.delete(B_DUMMY).catch(() => {});
+
+        if (useDynamo) {
+            const B_DYN = 'AT0002D';
+            testDataIds.add(B_DYN);
+            await Promise.all(
+                Array.from({ length: 100 }, (_, i) =>
+                    $dynamo.increment(B_DYN, { slot: i + 1, tags: [`${i + 1}`] } as any),
+                ),
+            );
+            const dynB: any = await $dynamo.read(B_DYN);
+            expect2(dynB.slot).toEqual(5050);
+            expect2(dynB.tags.length).toEqual(100);
+            expect2(new Set(dynB.tags).size).toEqual(100);
+            await $dynamo.delete(B_DYN).catch(() => {});
+        }
+    }, 60_000);
 
     afterAll(async () => {
         if (PROFILE !== 'lemon') return;

--- a/src/cores/storage/storage-service.ts
+++ b/src/cores/storage/storage-service.ts
@@ -364,8 +364,8 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
      * apply Dynamo-style field whitelist when configured; otherwise return a shallow copy.
      */
     private pick<S extends object>(obj: S): Partial<S> {
+        if (!this._fields) return { ...obj };
         const source = DynamoService.normalize(obj);
-        if (!this._fields) return { ...source };
         return this._fields.reduce((N: any, key) => {
             const val = (source as any)[key];
             if (val !== undefined) N[key] = val;

--- a/src/cores/storage/storage-service.ts
+++ b/src/cores/storage/storage-service.ts
@@ -226,12 +226,14 @@ export class DynamoStorageService<T extends StorageModel> implements StorageServ
             return N;
         }, {});
         /* eslint-disable prettier/prettier */
-        const $I: Incrementable = !incrementals ? null : Object.keys(incrementals).reduce((M: Incrementable, key) => {
-            const val = (incrementals as any)[key];
-            if (typeof val !== 'number') throw new Error(`.${key} (${val}) should be number!`);
-            M[key] = val;
-            return M;
-        }, {});
+        const $I: Incrementable = !incrementals
+            ? null
+            : Object.keys(incrementals).reduce((M: Incrementable, key) => {
+                  const val = (incrementals as any)[key];
+                  if (typeof val !== 'number') throw new Error(`.${key} (${val}) should be number!`);
+                  M[key] = val;
+                  return M;
+              }, {});
         /* eslint-enable prettier/prettier */
         const ret: any = await this.$dynamo.updateItem(id, undefined, $U, $I);
         return ret as T;
@@ -275,27 +277,33 @@ export class DynamoStorageService<T extends StorageModel> implements StorageServ
      */
     public async increment(id: string, model: T, $update?: T): Promise<T> {
         if (!model && !$update) throw new Error('@item is required!');
+        const fields = this._fields || [];
+
         const $org: any = await this.read(id).catch(e => {
             if (`${e.message || e}`.startsWith('404 NOT FOUND')) return { id };
             throw e;
         });
-        const fields = this._fields || [];
         const $U: MyGeneral = fields.reduce((N: any, key) => {
             const val = $update ? ($update as any)[key] : undefined;
             if (val !== undefined) N[key] = val;
             return N;
         }, {});
-        const $I: Incrementable = fields.reduce((N: any, key) => {
+        const $I: Incrementable = fields.reduce((N: Incrementable, key) => {
             const val = (model as any)[key];
             if (val !== undefined) {
                 const org = ($org as any)[key];
-                //* check type matched!
                 if (org !== undefined && typeof org === 'number' && typeof val !== 'number')
                     throw new Error(`.${key} (${val}) should be number!`);
-                //* if not exists, update it.
-                if (org === undefined && typeof val === 'number') N[key] = val;
-                else if (typeof val !== 'number' && !Array.isArray(val)) $U[key] = val;
-                else N[key] = val;
+                if (typeof org === 'string' && (typeof val === 'number' || Array.isArray(val)))
+                    throw new Error(`.${key} (${val}) should be string!`);
+                if (Array.isArray(org) && !Array.isArray(val)) throw new Error(`.${key} (${val}) should be array!`);
+                if (org !== undefined && typeof val === 'number' && typeof org !== 'number')
+                    throw new Error(`.${key} (${val}) should be number!`);
+                if (org !== undefined && Array.isArray(val) && !Array.isArray(org))
+                    throw new Error(`.${key} (${val}) should be array!`);
+
+                if (typeof val === 'number' || Array.isArray(val)) N[key] = val;
+                else $U[key] = val;
             }
             return N;
         }, {});
@@ -376,13 +384,11 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
 
     private applyDynamoAdd(key: string, org: any, val: any) {
         if (Array.isArray(val)) {
-            if (org !== undefined && !Array.isArray(org))
-                throw new Error(`.${key} (${val}) cannot append to non-list existing value`);
+            if (org !== undefined && !Array.isArray(org)) throw new Error(`.${key} (${val}) should be array!`);
             return [...(Array.isArray(org) ? org : []), ...val];
         }
         if (typeof val === 'number') {
-            if (org !== undefined && typeof org !== 'number')
-                throw new Error(`.${key} (${val}) cannot ADD to non-number existing value`);
+            if (org !== undefined && typeof org !== 'number') throw new Error(`.${key} (${val}) should be number!`);
             return $U.N(org, 0) + val;
         }
         throw new Error(`.${key} (${val}) should be number!`);
@@ -455,11 +461,33 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
     }
 
     private $locks: any = {}; //* only for lock.
+
+    //* serialize increment() by id.
+    private $queues: { [id: string]: Promise<unknown> } = {};
+    private withLock<R>(id: string, fn: () => Promise<R>): Promise<R> {
+        const prev = this.$queues[id] ?? Promise.resolve();
+        const run: Promise<R> = prev.catch((): undefined => undefined).then((): Promise<R> => fn());
+        const tail: Promise<void> = run
+            .then(
+                (): undefined => undefined,
+                (): undefined => undefined,
+            )
+            .then((): void => {
+                if (this.$queues[id] === tail) delete this.$queues[id];
+            });
+        this.$queues[id] = tail;
+        return run;
+    }
+
     public async update(id: string, item: T, $inc?: T): Promise<T> {
         if (!id) throw new Error('@id is required!');
         if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
         if (!item) throw new Error('@item is required!');
-        //* atomic operation for `.lock` — dummy-only deviation; DynamoDB has no equivalent here.
+        return this.withLock(id, () => this._updateBody(id, item, $inc));
+    }
+
+    private async _updateBody(id: string, item: T, $inc?: T): Promise<T> {
+        //* atomic operation for `.lock`.
         const lock = (() => {
             let lock = 0;
             if (item && typeof (item as any).lock == 'number') this.$locks[id] = lock = (item as any).lock;
@@ -472,16 +500,18 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         const filtered = this.pick(item) as Partial<T>;
         const $new: any = Object.assign($org, filtered);
         /* eslint-disable prettier/prettier */
-        const incremented: Incrementable = !$inc ? null : Object.keys($inc).reduce((M: Incrementable, key) => {
-            const val = ($inc as any)[key];
-            if (typeof val !== 'number') throw new Error(`.${key} (${val}) should be number!`);
-            if (key == 'lock') {
-                M[key] = lock;
-            } else {
-                M[key] = this.applyDynamoAdd(key, ($new as any)[key], val);
-            }
-            return M;
-        }, {});
+        const incremented: Incrementable = !$inc
+            ? null
+            : Object.keys($inc).reduce((M: Incrementable, key) => {
+                  const val = ($inc as any)[key];
+                  if (typeof val !== 'number') throw new Error(`.${key} (${val}) should be number!`);
+                  if (key == 'lock') {
+                      M[key] = lock;
+                  } else {
+                      M[key] = this.applyDynamoAdd(key, ($new as any)[key], val) as number;
+                  }
+                  return M;
+              }, {});
         if (incremented) Object.assign($new, incremented);
         /* eslint-enable prettier/prettier */
         await this.save(id, $new);
@@ -515,7 +545,11 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
         if (!id || !`${id}`.trim()) throw new Error('@id (string) is required!');
         if (!$inc && !$upt) throw new Error('@item is required!');
         if (!$inc) throw new TypeError('Cannot convert undefined or null to object');
-        //* atomic operation for `.lock` — dummy-only deviation; DynamoDB has no equivalent here.
+        return this.withLock(id, () => this._incrementBody(id, $inc, $upt));
+    }
+
+    private async _incrementBody(id: string, $inc: T, $upt?: T): Promise<T> {
+        //* atomic operation for `.lock`.
         const lock = (() => {
             let lock = 0;
             if ($upt && typeof ($upt as any).lock == 'number') this.$locks[id] = lock = ($upt as any).lock;
@@ -524,11 +558,9 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
             return lock;
         })();
         const $org: any = await this.readSafe(id);
-        //* null-guard: previously `Object.keys($inc)` threw when only $upt was provided.
         const inc: any = $inc ? DynamoService.normalize($inc) : {};
         const upt: any = $upt ? DynamoService.normalize($upt) : {};
-        //* iterate over the whitelist when configured (parity with Dynamo at storage-service.ts:283-301);
-        //* otherwise fall back to the union of provided keys (legacy unfiltered behavior).
+        //* use whitelist if exists.
         const keys: string[] = this._fields
             ? this._fields
             : Array.from(new Set([...Object.keys(inc), ...Object.keys(upt)]));
@@ -541,19 +573,25 @@ export class DummyStorageService<T extends StorageModel> implements StorageServi
                 $set[key] = uptVal;
                 $org[key] = uptVal;
             } else if (incVal !== undefined) {
-                if (org !== undefined && typeof org === 'number' && typeof incVal !== 'number')
-                    throw new Error(`.${key} (${incVal}) should be number!`);
                 if (key === 'lock') {
                     $set[key] = lock;
                     $org[key] = lock;
-                } else if (typeof incVal !== 'number' && !Array.isArray(incVal)) {
-                    //* non-number SET, matching DynamoStorage.increment's SET path.
-                    $set[key] = incVal;
-                    $org[key] = incVal;
                 } else {
-                    const newVal = this.applyDynamoAdd(key, org, incVal);
-                    $set[key] = newVal;
-                    $org[key] = newVal;
+                    if (org !== undefined && typeof org === 'number' && typeof incVal !== 'number')
+                        throw new Error(`.${key} (${incVal}) should be number!`);
+                    if (typeof org === 'string' && (typeof incVal === 'number' || Array.isArray(incVal)))
+                        throw new Error(`.${key} (${incVal}) should be string!`);
+                    if (Array.isArray(org) && !Array.isArray(incVal))
+                        throw new Error(`.${key} (${incVal}) should be array!`);
+                    if (typeof incVal === 'number' || Array.isArray(incVal)) {
+                        const newVal = this.applyDynamoAdd(key, org, incVal);
+                        $set[key] = newVal;
+                        $org[key] = newVal;
+                    } else {
+                        //* string/null/object as SET.
+                        $set[key] = incVal;
+                        $org[key] = incVal;
+                    }
                 }
             }
         }

--- a/src/engine/builder.spec.ts
+++ b/src/engine/builder.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi, test } from 'vitest';
 import { GETERR, expect2 } from '../common/test-helper';
 
 import { EngineModule, EngineOption, EngineScope, EngineConsole } from './types';

--- a/src/engine/builder.spec.ts
+++ b/src/engine/builder.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi, test } from 'vitest';
 import { GETERR, expect2 } from '../common/test-helper';
 

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi, test } from 'vitest';
 import { do_parrallel, doReportError } from './engine';
 import { convDate, convDateToTime, convDateToTS } from './engine';
 import { GETERR, expect2, _it } from '../common/test-helper';

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi, test } from 'vitest';
 import { do_parrallel, doReportError } from './engine';
 import { convDate, convDateToTime, convDateToTS } from './engine';

--- a/src/engine/utilities.spec.ts
+++ b/src/engine/utilities.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi, test } from 'vitest';
 import { expect2 } from '../common/test-helper';
 import { Utilities } from './utilities';
 

--- a/src/engine/utilities.spec.ts
+++ b/src/engine/utilities.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi, test } from 'vitest';
 import { expect2 } from '../common/test-helper';
 import { Utilities } from './utilities';

--- a/src/environ.spec.ts
+++ b/src/environ.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2025 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import loadEnviron, { credentials, loadProfile } from './environ';
 import { expect2 } from './common/test-helper';

--- a/src/environ.spec.ts
+++ b/src/environ.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2025 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import loadEnviron, { credentials, loadProfile } from './environ';
 import { expect2 } from './common/test-helper';
 

--- a/src/extended/abstract-service.spec.ts
+++ b/src/extended/abstract-service.spec.ts
@@ -9,6 +9,7 @@
  * @origin      see `lemon-accounts-api/src/service/core-service.spec.ts`
  * @copyright   (C) 2022 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../environ';
 import { CoreModel, NextContext, SearchBody } from '../cores/';

--- a/src/extended/abstract-service.spec.ts
+++ b/src/extended/abstract-service.spec.ts
@@ -9,7 +9,7 @@
  * @origin      see `lemon-accounts-api/src/service/core-service.spec.ts`
  * @copyright   (C) 2022 LemonCloud Co Ltd. - All Rights Reserved.
  */
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../environ';
 import { CoreModel, NextContext, SearchBody } from '../cores/';
 import { _it, expect2, GETERR } from '../common/test-helper';

--- a/src/extended/libs/sig-v4.spec.ts
+++ b/src/extended/libs/sig-v4.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) lemoncloud.io 2024 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { asyncCredentials } from '../../tools/tools';
 import { expect2, GETERR } from '../../common/test-helper';
 import { createSigV4Proxy } from '../../helpers/helpers';

--- a/src/extended/libs/sig-v4.spec.ts
+++ b/src/extended/libs/sig-v4.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) lemoncloud.io 2024 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { asyncCredentials } from '../../tools/tools';
 import { expect2, GETERR } from '../../common/test-helper';

--- a/src/helpers/helpers.spec.ts
+++ b/src/helpers/helpers.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../environ';
 import { $U } from '../engine';
 import { loadJsonSync } from '../tools/';

--- a/src/helpers/helpers.spec.ts
+++ b/src/helpers/helpers.spec.ts
@@ -7,6 +7,7 @@
  *
  * @copyright (C) 2020 LemonCloud Co Ltd. - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { loadProfile } from '../environ';
 import { $U } from '../engine';

--- a/src/tools/express.spec.ts
+++ b/src/tools/express.spec.ts
@@ -9,6 +9,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../common/test-helper';
 import { buildEngine } from '../engine';
 import { EnvironmentSet } from '../environ';

--- a/src/tools/express.spec.ts
+++ b/src/tools/express.spec.ts
@@ -9,6 +9,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi } from 'vitest';
 import { expect2 } from '../common/test-helper';
 import { buildEngine } from '../engine';

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -8,7 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
-import { vi } from 'vitest';
+import { describe, expect, it, vi, beforeAll, test } from 'vitest';
 import loadEnviron from '../environ'; //INFO! load environ first.
 import { expect2, GETERR, onlyDefined } from '../common/test-helper';
 import { loadJsonSync, awsConfig, AwsConfigParams, isLambda } from './tools';

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -8,6 +8,7 @@
  *
  * @copyright (C) lemoncloud.io 2019 - All Rights Reserved.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, expect, it, vi, beforeAll, test } from 'vitest';
 import loadEnviron from '../environ'; //INFO! load environ first.
 import { expect2, GETERR, onlyDefined } from '../common/test-helper';


### PR DESCRIPTION
# StorageService 개선 사항 요약

## 변경 내용

* `DynamoStorageService.increment()` 동작 개선
  * `string[]`: 배열 append

* 테스트 코드 정리
  * 전체 spec 파일에 Vitest explicit import 적용

---

## 테스트 검증 및 강화

### Increment 동작 검증

* `number` 필드 누적 증가
* `string[]` 필드 append
* `string` 필드 overwrite
* `null`, `object`, empty array 처리
* `increment(model, $update)` 조합 동작

### 타입 mismatch 검증

* `number` 필드에 `string` / `null`
* `string` 필드에 `number` / `array`
* `array` 필드에 `string`

### 안정성 검증

* 실패한 `increment()` 호출이 기존 상태를 오염시키지 않는지 확인
* `Promise.all` 기반 동시성 검증

  * number add 100회 누적
  * array append 100회 누적
  * `increment()` 단독 동시성
  * `update(..., increments)` 단독 동시성
  * `increment()` + `update(..., increments)` 혼합 동시성
  * `number` / `string` / `string[]` / `object` 혼합 parameter 동시성

---

## 테스트 결과

아래 명령어로 검증 완료했습니다.

```bash
npm run test -- src/cores/storage/storage-service.spec.ts
npm run test
ENV=lemon npm run test -- src/cores/storage/storage-service.spec.ts
ENV=lemon npm run test
```

결과:

```text
40 passed
378 passed
```

## string concat 관련
이번 PR에는 **string concat 기능을 추가하지 않았습니다.**

DynamoDB에서 문자열 concat은 원자적 update 연산으로 바로 지원되지 않아서,
동시성을 보장하려면 **version/condition 기반 retry 같은 별도 설계가 필요**합니다.

따라서 이번 PR은 atomic 보장이 가능한 string[] append만 개선했습니다.
concat atomic 보장을 위한 별도 설계들을 고려해서 string concat도 마저 개선할지 리뷰 부탁드립니다🙇‍♀️
