### PR TITLE
Feat/opt aws lambda invoke with event

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
 
 | Version   | Description
 |--         |--
+| 4.2.6     | optimized `$protocol.execute()` to support async lambda invocation.
 | 4.2.5     | optimized `isBase64Encoded` to support apigwBinary. (from `4.1.17`)
 | 4.2.4     | optimized `doReportError` to ignore in local dev. (from `4.1.16`)
 | 4.2.3     | optimized `ManagerProxy.inc()` w/ `string[]` parameters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemon-core",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lemon-core",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.971.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "doc:publish": "npm run doc:html && gh-pages -m \"docs(gh-pages): publish gh-pages via typedoc\" -d dist/docs",
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts,jsx,tsx}' --fix",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
+    "example:lambda": "ts-node src/tools/aws-lambda-helper.example.ts",
     "!test": "------- run self-test with vitest -----",
     "test": "LS=1 vitest run",
     "test.lemon": "ENV=lemon npm run test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemon-core",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "Lemon Serverless Micro-Service Platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,7 +17,6 @@
     "doc:publish": "npm run doc:html && gh-pages -m \"docs(gh-pages): publish gh-pages via typedoc\" -d dist/docs",
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts,jsx,tsx}' --fix",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
-    "example:lambda": "ts-node src/tools/aws-lambda-helper.example.ts",
     "!test": "------- run self-test with vitest -----",
     "test": "LS=1 vitest run",
     "test.lemon": "ENV=lemon npm run test",

--- a/src/cores/core-services.ts
+++ b/src/cores/core-services.ts
@@ -129,6 +129,21 @@ export interface ProtocolTransformer<TEventParam = any, TLambdaEvent = TEventPar
 }
 
 /**
+ * type: `ProtocolExecuteOptions`
+ * - options for `ProtocolService.execute()`
+ */
+export interface ProtocolExecuteOptions {
+    /** custom uri to provide */
+    uri?: string;
+    /**
+     * if true, invoke lambda asynchronously with InvocationType 'Event'.
+     *
+     * NOTE - ONLY for AWS Lambda, if useEvent is true, then `execute()` will return directly.
+     */
+    useEvent?: boolean;
+}
+
+/**
  * class: `ProtocolService`
  * - support inter communication (sync or async) between micro-services.
  */
@@ -153,7 +168,7 @@ export interface ProtocolService {
      * @param config    (optional) custom config
      * @param uri       (optional) custom uri to provide.
      */
-    execute<T>(param: ProtocolParam, config?: CoreConfigService, uri?: string): Promise<T>;
+    execute<T>(param: ProtocolParam, config?: CoreConfigService, uri?: string | ProtocolExecuteOptions): Promise<T>;
 
     /**
      * asynchronous call to target function via 'SNS'.

--- a/src/cores/protocol/aws-lambda-helper.spec.ts
+++ b/src/cores/protocol/aws-lambda-helper.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * `aws-lambda-helper.spec.ts`
+ * - unit test for `aws-lambda-helper`
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GETERR } from '../../common/test-helper';
+
+const lambdaMock = vi.hoisted(() => ({
+    clients: [] as object[],
+    send: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-lambda', () => {
+    class InvokeCommand {
+        public readonly input: object;
+        public constructor(input: object) {
+            this.input = input;
+        }
+    }
+
+    class LambdaClient {
+        public readonly send = lambdaMock.send;
+        public constructor(config: object) {
+            lambdaMock.clients.push(config);
+        }
+    }
+
+    return { InvokeCommand, LambdaClient };
+});
+
+import { invokeLambda } from './aws-lambda-helper';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+
+type InvokeInput = {
+    FunctionName: string;
+    Payload?: Uint8Array;
+    InvocationType?: string;
+};
+
+const encodeLambdaPayload = (payload: object): Uint8Array => new TextEncoder().encode(JSON.stringify(payload));
+const decodeInputPayload = (input: InvokeInput): string => new TextDecoder().decode(input.Payload);
+const lastInvokeInput = (): InvokeInput => lambdaMock.send.mock.calls.at(-1)?.[0]?.input as InvokeInput;
+
+const asEvent = (base?: Partial<APIGatewayProxyEvent>): APIGatewayProxyEvent =>
+    ({
+        httpMethod: 'POST',
+        path: '/hello/0',
+        headers: { 'content-type': 'application/json' },
+        multiValueHeaders: {},
+        queryStringParameters: { q: 'test' },
+        multiValueQueryStringParameters: null,
+        pathParameters: { type: 'hello', id: '0', cmd: '' },
+        requestContext: {
+            accountId: '1234',
+            httpMethod: 'POST',
+            identity: null as any,
+            path: '/hello/0',
+            requestId: 'req-1',
+            stage: 'dev',
+        },
+        body: JSON.stringify({ name: 'lemon' }),
+        isBase64Encoded: false,
+        ...base,
+    } as APIGatewayProxyEvent);
+
+describe('invokeLambda', () => {
+    beforeEach(() => {
+        lambdaMock.clients.splice(0);
+        lambdaMock.send.mockReset();
+    });
+
+    it('should prepare InvokeCommand input from API Gateway event payload', async () => {
+        const body = { ok: true, count: 2 };
+        const event = asEvent();
+        lambdaMock.send.mockResolvedValueOnce({
+            StatusCode: 200,
+            Payload: encodeLambdaPayload({ statusCode: 200, body: JSON.stringify(body) }),
+        });
+
+        const res = await invokeLambda('target-lambda', event, {
+            param: { service: 'target-service', type: 'hello', context: {} },
+            config: { region: 'ap-northeast-2' },
+        });
+
+        expect(res).toEqual(body);
+        expect(lambdaMock.clients).toEqual([{ region: 'ap-northeast-2' }]);
+        expect(lastInvokeInput().FunctionName).toBe('target-lambda');
+        expect(lastInvokeInput().InvocationType).toBeUndefined();
+        expect(JSON.parse(decodeInputPayload(lastInvokeInput()))).toEqual(event);
+    });
+
+    it('should send raw string payload without JSON wrapping', async () => {
+        lambdaMock.send.mockResolvedValueOnce({
+            StatusCode: 200,
+            Payload: encodeLambdaPayload({ statusCode: 200, body: JSON.stringify({ accepted: true }) }),
+        });
+
+        const res = await invokeLambda('target-lambda', '{"raw":true}');
+
+        expect(res).toEqual({ accepted: true });
+        expect(decodeInputPayload(lastInvokeInput())).toBe('{"raw":true}');
+    });
+
+    it('should enable asynchronous Event invocation when useEvent is true', async () => {
+        lambdaMock.send.mockResolvedValueOnce({ StatusCode: 202 });
+
+        const res = await invokeLambda('target-lambda', asEvent(), { useEvent: true });
+
+        expect(res).toEqual({ StatusCode: 202, Payload: undefined });
+        expect(lastInvokeInput().InvocationType).toBe('Event');
+    });
+
+    it('should read payload.text before payload.body', async () => {
+        lambdaMock.send.mockResolvedValueOnce({
+            StatusCode: 200,
+            Payload: encodeLambdaPayload({
+                statusCode: 200,
+                text: 'plain text result',
+                body: JSON.stringify({ ok: false }),
+            }),
+        });
+
+        const res = await invokeLambda('target-lambda', asEvent());
+
+        expect(res).toBe('plain text result');
+    });
+
+    it('should keep non JSON body string when body parsing fails', async () => {
+        lambdaMock.send.mockResolvedValueOnce({
+            StatusCode: 200,
+            Payload: encodeLambdaPayload({ statusCode: 200, body: 'not-json-body' }),
+        });
+
+        const res = await invokeLambda('target-lambda', asEvent());
+
+        expect(res).toBe('not-json-body');
+    });
+
+    it('should reject 400 and 404 status with parsed body message', async () => {
+        lambdaMock.send.mockResolvedValueOnce({
+            StatusCode: 200,
+            Payload: encodeLambdaPayload({ statusCode: 404, body: JSON.stringify('404 NOT FOUND - test') }),
+        });
+
+        const err = await invokeLambda('target-lambda', asEvent()).catch(GETERR);
+
+        expect(err).toBe('404 NOT FOUND - test');
+    });
+
+    it('should reject non success status with Lambda Error message', async () => {
+        lambdaMock.send.mockResolvedValueOnce({
+            StatusCode: 200,
+            Payload: encodeLambdaPayload({ statusCode: 500, body: JSON.stringify({ error: 'broken' }) }),
+        });
+
+        const err = await invokeLambda('target-lambda', asEvent()).catch(GETERR);
+
+        expect(err).toBe('{"error":"broken"}');
+    });
+
+    it('should rethrow LambdaClient send errors', async () => {
+        lambdaMock.send.mockRejectedValueOnce(new Error('network is unavailable'));
+
+        const err = await invokeLambda('target-lambda', asEvent(), {
+            param: { service: 'target-service', type: 'hello', context: {} },
+        }).catch(GETERR);
+
+        expect(err).toBe('network is unavailable');
+    });
+
+    it('should reject when target is empty before creating LambdaClient', async () => {
+        const err = await invokeLambda('', asEvent()).catch(GETERR);
+
+        expect(err).toBe('@target(function) is required - invokeLambda()');
+        expect(lambdaMock.clients).toEqual([]);
+        expect(lambdaMock.send).not.toHaveBeenCalled();
+    });
+});

--- a/src/cores/protocol/aws-lambda-helper.ts
+++ b/src/cores/protocol/aws-lambda-helper.ts
@@ -5,6 +5,14 @@ import { ProtocolParam } from '../core-services';
 import { AwsConfigParams } from '../../tools/tools';
 const NS = $U.NS('PRTS', 'yellow'); // NAMESPACE TO BE PRINTED.
 
+const asPayloadText = (payload?: Uint8Array): string | undefined =>
+    payload ? Buffer.from(payload).toString() : undefined;
+
+const asInvokeLogData = (data: InvokeCommandOutput): Omit<InvokeCommandOutput, 'Payload'> & { Payload?: string } => ({
+    ...data,
+    Payload: asPayloadText(data.Payload),
+});
+
 /**
  * invoke lambda function with given payload.
  * - `param` is used for logging and error reporting.
@@ -43,11 +51,17 @@ export async function invokeLambda<T>(
             throw e;
         })
         .then((data: InvokeCommandOutput) => {
-            _log(NS, `! execute[${param?.service ?? ''}].res =`, $U.S(data, 320, 64, ' .... '));
-            const payload = data && data?.Payload ? JSON.parse(Buffer.from(data.Payload).toString()) : {};
+            const payloadText = asPayloadText(data?.Payload);
+            _log(NS, `! execute[${param?.service ?? ''}].res =`, $U.S(asInvokeLogData(data), 320, 64, ' .... '));
+            const payload = payloadText ? JSON.parse(payloadText) : {};
             const statusCode = $U.N(payload.statusCode || (data && data.StatusCode), 200);
             _log(NS, `> Lambda[${params.FunctionName}].StatusCode :=`, statusCode);
-            [200, 201].includes(statusCode) || _inf(NS, `> WARN! status[${statusCode}] data =`, $U.S(data)); // print whole data if not 200.
+            _log(NS, `> Lambda[${params.FunctionName}].ContentSize :=`, payloadText ? payloadText.length : 0);
+
+            //* for debug, print whole data if status code is not 200 or 201.
+            const hasWarn = ![200, 201].includes(statusCode);
+            if (hasWarn) _inf(NS, `> WARN! status[${statusCode}] data =`, $U.S(asInvokeLogData(data)));
+
             //* safe parse payload.body.
             const body = (() => {
                 try {
@@ -58,6 +72,7 @@ export async function invokeLambda<T>(
                     return payload.body;
                 }
             })();
+
             //* returns
             if (statusCode == 400 || statusCode == 404) return Promise.reject(new Error($U.S(body) || '404 NOT FOUND'));
             else if (statusCode != 200 && statusCode != 201) {

--- a/src/cores/protocol/aws-lambda-helper.ts
+++ b/src/cores/protocol/aws-lambda-helper.ts
@@ -1,0 +1,71 @@
+import { _log, _inf, _err, $U } from '../../engine/';
+import { InvocationRequest, InvokeCommand, InvokeCommandOutput, LambdaClient } from '@aws-sdk/client-lambda';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { ProtocolParam } from '../core-services';
+import { AwsConfigParams } from '../../tools/tools';
+const NS = $U.NS('PRTS', 'yellow'); // NAMESPACE TO BE PRINTED.
+
+/**
+ * invoke lambda function with given payload.
+ * - `param` is used for logging and error reporting.
+ */
+export async function invokeLambda<T>(
+    target: string,
+    payload: APIGatewayProxyEvent | string,
+    options?: {
+        param?: ProtocolParam;
+        config?: AwsConfigParams;
+    },
+): Promise<T> {
+    const param: ProtocolParam | undefined = options?.param;
+    const config: AwsConfigParams = options?.config ?? {};
+    const errScope = `invokeLambda(${target ?? ''})`;
+    if (!target) throw new Error(`@target(function) is required - ${errScope}`);
+
+    //* prepare lambda payload.
+    const params: InvocationRequest = {
+        FunctionName: target,
+        Payload: payload
+            ? new TextEncoder().encode(typeof payload === 'string' ? payload : $U.json(payload))
+            : undefined,
+        ClientContext: undefined,
+        // InvocationType: 'Event',
+    };
+    // _log(NS, `> params =`, $U.json(params));
+
+    //* call lambda.
+    const lambda = new LambdaClient(config);
+    const response = await lambda
+        .send(new InvokeCommand(params))
+        .catch((e: Error) => {
+            _err(NS, `! execute[${param?.service ?? ''}].err =`, typeof e, e);
+            // return this.doReportError(e, param.context, null, { protocol: uri, param });
+            throw e;
+        })
+        .then((data: InvokeCommandOutput) => {
+            _log(NS, `! execute[${param?.service ?? ''}].res =`, $U.S(data, 320, 64, ' .... '));
+            const payload = data && data?.Payload ? JSON.parse(Buffer.from(data.Payload).toString()) : {};
+            const statusCode = $U.N(payload.statusCode || (data && data.StatusCode), 200);
+            _log(NS, `> Lambda[${params.FunctionName}].StatusCode :=`, statusCode);
+            [200, 201].includes(statusCode) || _inf(NS, `> WARN! status[${statusCode}] data =`, $U.S(data)); // print whole data if not 200.
+            //* safe parse payload.body.
+            const body = (() => {
+                try {
+                    if (payload.text && typeof payload.text == 'string') return payload.text;
+                    return payload.body && typeof payload.body == 'string' ? JSON.parse(payload.body) : payload.body;
+                } catch (e) {
+                    _log(NS, `> WARN! payload.body =`, $U.S(payload.body));
+                    return payload.body;
+                }
+            })();
+            //* returns
+            if (statusCode == 400 || statusCode == 404) return Promise.reject(new Error($U.S(body) || '404 NOT FOUND'));
+            else if (statusCode != 200 && statusCode != 201) {
+                if (typeof body == 'string' && body.startsWith('404 NOT FOUND')) throw new Error(body);
+                throw new Error($U.S(body) || `Lambda Error. status:${statusCode}`);
+            }
+            return body;
+        });
+    const res: T = response as T;
+    return res;
+}

--- a/src/cores/protocol/aws-lambda-helper.ts
+++ b/src/cores/protocol/aws-lambda-helper.ts
@@ -61,6 +61,7 @@ export async function invokeLambda<T>(
             _log(NS, `> Lambda[${params.FunctionName}].StatusCode :=`, statusCode);
             _log(NS, `> Lambda[${params.FunctionName}].ContentSize :=`, payloadText ? payloadText.length : 0);
 
+            //* if useEvent is true and status code is 202, then return directly without parsing payload.
             if (useEvent && statusCode == 202) return asInvokeLogData(data);
 
             //* for debug, print whole data if status code is not 200 or 201.

--- a/src/cores/protocol/aws-lambda-helper.ts
+++ b/src/cores/protocol/aws-lambda-helper.ts
@@ -1,9 +1,10 @@
 import { _log, _inf, _err, $U } from '../../engine/';
-import { InvocationRequest, InvokeCommand, InvokeCommandOutput, LambdaClient } from '@aws-sdk/client-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import { onlyDefined } from '../../common/test-helper';
 import { ProtocolParam } from '../core-services';
 import { AwsConfigParams } from '../../tools/tools';
-const NS = $U.NS('PRTS', 'yellow'); // NAMESPACE TO BE PRINTED.
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { InvocationRequest, InvokeCommand, InvokeCommandOutput, LambdaClient } from '@aws-sdk/client-lambda';
+const NS = $U.NS('PRTL', 'yellow'); // NAMESPACE TO BE PRINTED.
 
 const asPayloadText = (payload?: Uint8Array): string | undefined =>
     payload ? Buffer.from(payload).toString() : undefined;
@@ -23,22 +24,24 @@ export async function invokeLambda<T>(
     options?: {
         param?: ProtocolParam;
         config?: AwsConfigParams;
+        useEvent?: boolean; // if true, invoke lambda asynchronously with InvocationType 'Event'.
     },
 ): Promise<T> {
     const param: ProtocolParam | undefined = options?.param;
     const config: AwsConfigParams = options?.config ?? {};
+    const useEvent = options?.useEvent ?? false;
     const errScope = `invokeLambda(${target ?? ''})`;
     if (!target) throw new Error(`@target(function) is required - ${errScope}`);
 
     //* prepare lambda payload.
-    const params: InvocationRequest = {
+    const params = onlyDefined<InvocationRequest>({
         FunctionName: target,
         Payload: payload
             ? new TextEncoder().encode(typeof payload === 'string' ? payload : $U.json(payload))
             : undefined,
         ClientContext: undefined,
-        // InvocationType: 'Event',
-    };
+        InvocationType: useEvent ? 'Event' : undefined,
+    });
     // _log(NS, `> params =`, $U.json(params));
 
     //* call lambda.
@@ -57,6 +60,8 @@ export async function invokeLambda<T>(
             const statusCode = $U.N(payload.statusCode || (data && data.StatusCode), 200);
             _log(NS, `> Lambda[${params.FunctionName}].StatusCode :=`, statusCode);
             _log(NS, `> Lambda[${params.FunctionName}].ContentSize :=`, payloadText ? payloadText.length : 0);
+
+            if (useEvent && statusCode == 202) return asInvokeLogData(data);
 
             //* for debug, print whole data if status code is not 200 or 201.
             const hasWarn = ![200, 201].includes(statusCode);

--- a/src/cores/protocol/protocol-service.ts
+++ b/src/cores/protocol/protocol-service.ts
@@ -18,6 +18,7 @@ import {
     ProtocolTransformer,
     ProtocolBody,
     CallbackParam,
+    ProtocolExecuteOptions,
 } from './../core-services';
 import { PublishCommand, PublishCommandInput, PublishCommandOutput, SNSClient } from '@aws-sdk/client-sns';
 import { SendMessageCommand, SendMessageCommandInput, SendMessageCommandOutput, SQSClient } from '@aws-sdk/client-sqs';
@@ -318,20 +319,26 @@ export class MyProtocolService implements ProtocolService {
      * @param config    config service (for debug)
      * @param uri       (optional) if useing custom uri.
      */
-    public async execute<T>(param: ProtocolParam, config?: ConfigService, uri?: string): Promise<T> {
+    public async execute<T>(
+        param: ProtocolParam,
+        config?: ConfigService,
+        options?: string | ProtocolExecuteOptions,
+    ): Promise<T> {
         // const _log = console.info;
         config = config || this.config;
         _log(NS, `execute(${param.service || ''})..`);
+        const url = typeof options == 'string' ? options : options?.uri;
+        const useEvent = typeof options == 'object' ? options.useEvent : undefined;
 
         //* execute via lambda call.
-        uri = uri || this.asProtocolURI('web', param, config);
+        const uri = url || this.asProtocolURI('web', param, config);
         _inf(NS, `> uri =`, uri);
 
         // const url = new URL(uri);
-        const url = URL.parse(uri);
+        const $url = URL.parse(uri);
         const payload = this.transformEvent(uri, param) as APIGatewayProxyEvent;
         const awsCfg = awsConfig($engine);
-        return invokeLambda<T>(url.hostname!, payload, { param, config: awsCfg });
+        return invokeLambda<T>($url.hostname!, payload, { param, config: awsCfg, useEvent });
     }
 
     /**

--- a/src/cores/protocol/protocol-service.ts
+++ b/src/cores/protocol/protocol-service.ts
@@ -328,7 +328,7 @@ export class MyProtocolService implements ProtocolService {
         config = config || this.config;
         _log(NS, `execute(${param.service || ''})..`);
         const url = typeof options == 'string' ? options : options?.uri;
-        const useEvent = typeof options == 'object' ? options.useEvent : undefined;
+        const useEvent = options != null && typeof options == 'object' ? options.useEvent : undefined;
 
         //* execute via lambda call.
         const uri = url || this.asProtocolURI('web', param, config);

--- a/src/cores/protocol/protocol-service.ts
+++ b/src/cores/protocol/protocol-service.ts
@@ -21,7 +21,6 @@ import {
 } from './../core-services';
 import { PublishCommand, PublishCommandInput, PublishCommandOutput, SNSClient } from '@aws-sdk/client-sns';
 import { SendMessageCommand, SendMessageCommandInput, SendMessageCommandOutput, SQSClient } from '@aws-sdk/client-sqs';
-import { InvocationRequest, InvokeCommand, InvokeCommandOutput, LambdaClient } from '@aws-sdk/client-lambda';
 import { APIGatewayProxyEvent, APIGatewayEventRequestContext, SNSMessage, SQSRecord } from 'aws-lambda';
 import { ConfigService } from './../config/config-service';
 import { LambdaHandler } from './../lambda/lambda-handler';
@@ -30,6 +29,7 @@ import URL from 'url';
 import $conf from '../config/'; // load config-module.
 import $aws from '../aws/'; // load config-module.
 import queryString from 'qs';
+import { invokeLambda } from './aws-lambda-helper';
 const NS = $U.NS('PRTS', 'yellow'); // NAMESPACE TO BE PRINTED.
 
 /**
@@ -329,56 +329,9 @@ export class MyProtocolService implements ProtocolService {
 
         // const url = new URL(uri);
         const url = URL.parse(uri);
-        const payload = this.transformEvent(uri, param);
-
-        //* prepare lambda payload.
-        const params: InvocationRequest = {
-            FunctionName: url.hostname,
-            Payload: payload ? new TextEncoder().encode($U.json(payload)) : undefined,
-            ClientContext: undefined,
-            // InvocationType: 'Event',
-        };
-        // _log(NS, `> params =`, $U.json(params));
-
-        //* call lambda.
-        const region = 'ap-northeast-2'; //TODO - optimize of aws region....
-        const lambda = new LambdaClient(awsConfig($engine, region));
-        const response = await lambda
-            .send(new InvokeCommand(params))
-            .catch((e: Error) => {
-                _err(NS, `! execute[${param.service || ''}].err =`, typeof e, e);
-                // return this.doReportError(e, param.context, null, { protocol: uri, param });
-                throw e;
-            })
-            .then((data: InvokeCommandOutput) => {
-                _log(NS, `! execute[${param.service || ''}].res =`, $U.S(data, 320, 64, ' .... '));
-                const payload = data && data?.Payload ? JSON.parse(Buffer.from(data.Payload).toString()) : {};
-                const statusCode = $U.N(payload.statusCode || (data && data.StatusCode), 200);
-                _log(NS, `> Lambda[${params.FunctionName}].StatusCode :=`, statusCode);
-                [200, 201].includes(statusCode) || _inf(NS, `> WARN! status[${statusCode}] data =`, $U.S(data)); // print whole data if not 200.
-                //* safe parse payload.body.
-                const body = (() => {
-                    try {
-                        if (payload.text && typeof payload.text == 'string') return payload.text;
-                        return payload.body && typeof payload.body == 'string'
-                            ? JSON.parse(payload.body)
-                            : payload.body;
-                    } catch (e) {
-                        _log(NS, `> WARN! payload.body =`, $U.S(payload.body));
-                        return payload.body;
-                    }
-                })();
-                //* returns
-                if (statusCode == 400 || statusCode == 404)
-                    return Promise.reject(new Error($U.S(body) || '404 NOT FOUND'));
-                else if (statusCode != 200 && statusCode != 201) {
-                    if (typeof body == 'string' && body.startsWith('404 NOT FOUND')) throw new Error(body);
-                    throw new Error($U.S(body) || `Lambda Error. status:${statusCode}`);
-                }
-                return body;
-            });
-        const res: T = response as T;
-        return res;
+        const payload = this.transformEvent(uri, param) as APIGatewayProxyEvent;
+        const awsCfg = awsConfig($engine);
+        return invokeLambda<T>(url.hostname!, payload, { param, config: awsCfg });
     }
 
     /**

--- a/src/engine/utilities.ts
+++ b/src/engine/utilities.ts
@@ -168,7 +168,7 @@ export class Utilities {
                 });
             o = output;
         }
-        return o ? JSON.stringify(o) : typeof o == 'number' ? `${o}` : `${o || ''}`;
+        return o ? JSON.stringify(o) : typeof o == 'number' ? `${o}` : `${o ?? ''}`;
     }
 
     /**
@@ -404,7 +404,7 @@ export class Utilities {
      * convert and cut string like `abcd....z`
      */
     public S = (_: any, h?: number, t: number = 32, delim: string = '...'): string =>
-        [typeof _ == 'string' ? _ : `${this.json(_) || ''}`]
+        [typeof _ == 'string' ? _ : `${this.json(_) ?? ''}`]
             .map(s =>
                 h && s.length > h + t
                     ? s.substring(0, h) + delim + (s.length > h + t ? s.substring(s.length - t) : '')

--- a/src/tools/aws-lambda-helper.example.md
+++ b/src/tools/aws-lambda-helper.example.md
@@ -1,0 +1,37 @@
+# aws-lambda-helper 실행 예제
+
+`src/tools/aws-lambda-helper.example.ts`는 `invokeLambda()`의 실제 호출 입력과 응답 변환을 확인하기 위한 실행 스크립트입니다.
+
+기본 실행:
+
+```sh
+npx ts-node src/tools/aws-lambda-helper.example.ts
+```
+
+Lambda 대상, profile, region 지정:
+
+```sh
+npx ts-node src/tools/aws-lambda-helper.example.ts --target lemon-hello-api-dev-lambda --profile lemon --region ap-northeast-2
+```
+
+비동기 Lambda 호출:
+
+```sh
+npx ts-node src/tools/aws-lambda-helper.example.ts --target lemon-hello-api-dev-lambda --use-event
+```
+
+payload 지정:
+
+```sh
+npx ts-node src/tools/aws-lambda-helper.example.ts --payload-file ./data/samples/events/sample.event.web.api.json
+npx ts-node src/tools/aws-lambda-helper.example.ts --payload-json '{"httpMethod":"GET","path":"/hello"}'
+npx ts-node src/tools/aws-lambda-helper.example.ts --raw-payload '{"ping":"pong"}'
+```
+
+도움말:
+
+```sh
+npx ts-node src/tools/aws-lambda-helper.example.ts --help
+```
+
+기본값은 예제 파일의 `DEFAULT_ARGS`에서 조정할 수 있습니다.

--- a/src/tools/aws-lambda-helper.example.ts
+++ b/src/tools/aws-lambda-helper.example.ts
@@ -4,12 +4,12 @@
  *
  * Examples:
  * ```sh
- * npm run example:lambda
- * npm run example:lambda -- --target lemon-hello-api-dev-lambda --profile lemon
- * npm run example:lambda -- --target lemon-hello-api-dev-lambda --payload-json '{"httpMethod":"GET","path":"/hello"}'
- * npm run example:lambda -- --target lemon-hello-api-dev-lambda --raw-payload '{"ping":"pong"}'
- * npm run example:lambda -- --target lemon-hello-api-dev-lambda --payload-file ./data/samples/events/sample.event.web.api.json
- * npm run example:lambda -- --target lemon-hello-api-dev-lambda --use-event
+ * npx ts-node src/tools/aws-lambda-helper.example.ts
+ * npx ts-node src/tools/aws-lambda-helper.example.ts --target lemon-hello-api-dev-lambda --profile lemon
+ * npx ts-node src/tools/aws-lambda-helper.example.ts --target lemon-hello-api-dev-lambda --payload-json '{"httpMethod":"GET","path":"/hello"}'
+ * npx ts-node src/tools/aws-lambda-helper.example.ts --target lemon-hello-api-dev-lambda --raw-payload '{"ping":"pong"}'
+ * npx ts-node src/tools/aws-lambda-helper.example.ts --target lemon-hello-api-dev-lambda --payload-file ./data/samples/events/sample.event.web.api.json
+ * npx ts-node src/tools/aws-lambda-helper.example.ts --target lemon-hello-api-dev-lambda --use-event
  * ```
  */
 import fs from 'fs';
@@ -40,7 +40,7 @@ const DEFAULT_ARGS: ExampleArgs = {
 
 const HELP = `
 Usage:
-  npm run example:lambda -- [options]
+  npx ts-node src/tools/aws-lambda-helper.example.ts [options]
 
 Options:
   --target <name>         Lambda function name. default: ${DEFAULT_ARGS.target}

--- a/src/tools/aws-lambda-helper.example.ts
+++ b/src/tools/aws-lambda-helper.example.ts
@@ -1,0 +1,184 @@
+/**
+ * `aws-lambda-helper.example.ts`
+ * - runnable example for `invokeLambda()`.
+ *
+ * Examples:
+ * ```sh
+ * npm run example:lambda
+ * npm run example:lambda -- --target lemon-hello-api-dev-lambda --profile lemon
+ * npm run example:lambda -- --target lemon-hello-api-dev-lambda --payload-json '{"httpMethod":"GET","path":"/hello"}'
+ * npm run example:lambda -- --target lemon-hello-api-dev-lambda --raw-payload '{"ping":"pong"}'
+ * npm run example:lambda -- --target lemon-hello-api-dev-lambda --payload-file ./data/samples/events/sample.event.web.api.json
+ * ```
+ */
+import fs from 'fs';
+import { fromIni } from '@aws-sdk/credential-providers';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { $U } from '../engine';
+import { ProtocolParam } from '../cores/core-services';
+import { invokeLambda } from '../cores/protocol/aws-lambda-helper';
+import { AwsConfigParams } from './tools';
+
+type ExampleArgs = {
+    target: string;
+    profile?: string;
+    region: string;
+    payloadJson?: string;
+    payloadFile?: string;
+    rawPayload?: string;
+};
+
+const NS = '[lambda-example]';
+const DEFAULT_ARGS: ExampleArgs = {
+    target: 'lemon-hello-api-dev-lambda',
+    region: 'ap-northeast-2',
+    profile: undefined,
+};
+
+const HELP = `
+Usage:
+  npm run example:lambda -- [options]
+
+Options:
+  --target <name>         Lambda function name. default: ${DEFAULT_ARGS.target}
+  --profile <name>        AWS profile name. default: AWS SDK default credential chain
+  --region <region>       AWS region. default: ${DEFAULT_ARGS.region}
+  --payload-json <json>   APIGatewayProxyEvent JSON payload
+  --payload-file <path>   APIGatewayProxyEvent JSON file path
+  --raw-payload <string>  Raw string payload
+  --help                  Print this help
+`;
+
+const parseJson = <T>(label: string, value: string): T => {
+    try {
+        return JSON.parse(value) as T;
+    } catch (e) {
+        const message = e instanceof Error ? e.message : `${e}`;
+        throw new Error(`${label} is not valid JSON - ${message}`);
+    }
+};
+
+const defaultEvent = (): APIGatewayProxyEvent =>
+    ({
+        resource: '/hello',
+        path: '/hello',
+        httpMethod: 'GET',
+        headers: {
+            'content-type': 'application/json',
+            'x-protocol-context': JSON.stringify({ requestId: 'local-example', accountId: '' }),
+        },
+        multiValueHeaders: {},
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: { type: 'hello', id: '', cmd: '' },
+        stageVariables: null,
+        requestContext: {
+            accountId: '',
+            apiId: 'local-example',
+            authorizer: undefined,
+            protocol: 'HTTP/1.1',
+            httpMethod: 'GET',
+            identity: null as any,
+            path: '/hello',
+            stage: '',
+            requestId: 'local-example',
+            requestTimeEpoch: Date.now(),
+            resourceId: 'local-example',
+            resourcePath: '/hello',
+        },
+        body: null,
+        isBase64Encoded: false,
+    } as APIGatewayProxyEvent);
+
+const parseArgs = (argv: string[]): ExampleArgs => {
+    const args: ExampleArgs = { ...DEFAULT_ARGS };
+    const aliases: Record<string, keyof ExampleArgs> = {
+        '--target': 'target',
+        '--function-name': 'target',
+        '--profile': 'profile',
+        '--region': 'region',
+        '--payload-json': 'payloadJson',
+        '--payload-file': 'payloadFile',
+        '--raw-payload': 'rawPayload',
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const token = argv[i];
+        if (token == '--help' || token == '-h') {
+            console.info(HELP.trim());
+            process.exit(0);
+        }
+
+        const eqIndex = token.indexOf('=');
+        const key = eqIndex > 0 ? token.substring(0, eqIndex) : token;
+        const prop = aliases[key];
+        if (!prop) throw new Error(`Unknown option: ${token}`);
+
+        const value = eqIndex > 0 ? token.substring(eqIndex + 1) : argv[++i];
+        if (value === undefined || value.startsWith('--')) {
+            throw new Error(`${key} requires a value.`);
+        }
+        (args[prop] as string) = value;
+    }
+
+    return args;
+};
+
+const loadPayload = (args: ExampleArgs): APIGatewayProxyEvent | string => {
+    if (args.rawPayload) return args.rawPayload;
+    if (args.payloadJson) return parseJson<APIGatewayProxyEvent>('payloadJson', args.payloadJson);
+    if (args.payloadFile) {
+        const raw = fs.readFileSync(args.payloadFile, 'utf8');
+        return parseJson<APIGatewayProxyEvent>(`payloadFile(${args.payloadFile})`, raw);
+    }
+    return defaultEvent();
+};
+
+const buildConfig = (args: ExampleArgs): AwsConfigParams => {
+    const region = args.region;
+    const profile = args.profile;
+    return {
+        region,
+        profile,
+        credentials: profile ? fromIni({ profile }) : undefined,
+    };
+};
+
+const main = async () => {
+    const args = parseArgs(process.argv.slice(2));
+    const target = args.target;
+
+    const payload = loadPayload(args);
+    const config = buildConfig(args);
+    const param: ProtocolParam = {
+        service: target,
+        type: 'lambda-helper-example',
+        mode: (typeof payload === 'string' ? 'POST' : payload.httpMethod || 'GET') as ProtocolParam['mode'],
+        context: { requestId: `local-${Date.now()}`, accountId: '' },
+    };
+
+    console.info(NS, 'start invokeLambda()');
+    console.info(NS, 'target =', target);
+    console.info(NS, 'region =', config.region);
+    console.info(NS, 'profile =', config.profile || '(default credential chain)');
+    console.info(NS, 'payload.type =', typeof payload);
+    console.info(NS, 'payload.preview =', $U.S(payload, 720, 96, ' .... '));
+
+    const startedAt = Date.now();
+    try {
+        const result = await invokeLambda<unknown>(target, payload, { param, config });
+        console.info(NS, 'success = true');
+        console.info(NS, 'elapsed.ms =', Date.now() - startedAt);
+        console.info(NS, 'result =', $U.S(result, 1200, 128, ' .... '));
+    } catch (e) {
+        console.error(NS, 'success = false');
+        console.error(NS, 'elapsed.ms =', Date.now() - startedAt);
+        console.error(NS, 'error =', e instanceof Error ? e.stack || e.message : e);
+        process.exitCode = 1;
+    }
+};
+
+main().catch(e => {
+    console.error(NS, 'fatal =', e instanceof Error ? e.stack || e.message : e);
+    process.exitCode = 1;
+});

--- a/src/tools/aws-lambda-helper.example.ts
+++ b/src/tools/aws-lambda-helper.example.ts
@@ -64,9 +64,9 @@ const parseJson = <T>(label: string, value: string): T => {
 
 const defaultEvent = (): APIGatewayProxyEvent =>
     ({
-        resource: '/hello',
-        path: '/hello',
-        httpMethod: 'GET',
+        resource: '/hello/public/slack',
+        path: '/hello/public/slack',
+        httpMethod: 'POST',
         headers: {
             'content-type': 'application/json',
             'x-protocol-context': JSON.stringify({ requestId: 'local-example', accountId: '' }),
@@ -74,23 +74,23 @@ const defaultEvent = (): APIGatewayProxyEvent =>
         multiValueHeaders: {},
         queryStringParameters: null,
         multiValueQueryStringParameters: null,
-        pathParameters: { type: 'hello', id: '', cmd: '' },
+        pathParameters: { type: 'hello', id: 'public', cmd: 'slack' },
         stageVariables: null,
         requestContext: {
             accountId: '',
             apiId: 'local-example',
             authorizer: undefined,
             protocol: 'HTTP/1.1',
-            httpMethod: 'GET',
+            httpMethod: 'POST',
             identity: null as any,
-            path: '/hello',
+            path: '/hello/public/slack',
             stage: '',
             requestId: 'local-example',
             requestTimeEpoch: Date.now(),
             resourceId: 'local-example',
-            resourcePath: '/hello',
+            resourcePath: '/hello/public/slack',
         },
-        body: null,
+        body: $U.json({ text: `[${$U.ts()}] Hello from \`aws-lambda-helper.example.ts\`.` }),
         isBase64Encoded: false,
     } as APIGatewayProxyEvent);
 

--- a/src/tools/aws-lambda-helper.example.ts
+++ b/src/tools/aws-lambda-helper.example.ts
@@ -9,6 +9,7 @@
  * npm run example:lambda -- --target lemon-hello-api-dev-lambda --payload-json '{"httpMethod":"GET","path":"/hello"}'
  * npm run example:lambda -- --target lemon-hello-api-dev-lambda --raw-payload '{"ping":"pong"}'
  * npm run example:lambda -- --target lemon-hello-api-dev-lambda --payload-file ./data/samples/events/sample.event.web.api.json
+ * npm run example:lambda -- --target lemon-hello-api-dev-lambda --use-event
  * ```
  */
 import fs from 'fs';
@@ -26,6 +27,7 @@ type ExampleArgs = {
     payloadJson?: string;
     payloadFile?: string;
     rawPayload?: string;
+    useEvent: boolean;
 };
 
 const NS = '[lambda-example]';
@@ -33,6 +35,7 @@ const DEFAULT_ARGS: ExampleArgs = {
     target: 'lemon-hello-api-dev-lambda',
     region: 'ap-northeast-2',
     profile: undefined,
+    useEvent: false,
 };
 
 const HELP = `
@@ -46,6 +49,7 @@ Options:
   --payload-json <json>   APIGatewayProxyEvent JSON payload
   --payload-file <path>   APIGatewayProxyEvent JSON file path
   --raw-payload <string>  Raw string payload
+  --use-event             Invoke asynchronously with InvocationType 'Event'. default: ${DEFAULT_ARGS.useEvent}
   --help                  Print this help
 `;
 
@@ -101,6 +105,9 @@ const parseArgs = (argv: string[]): ExampleArgs => {
         '--payload-file': 'payloadFile',
         '--raw-payload': 'rawPayload',
     };
+    const flags: Record<string, keyof ExampleArgs> = {
+        '--use-event': 'useEvent',
+    };
 
     for (let i = 0; i < argv.length; i++) {
         const token = argv[i];
@@ -111,6 +118,12 @@ const parseArgs = (argv: string[]): ExampleArgs => {
 
         const eqIndex = token.indexOf('=');
         const key = eqIndex > 0 ? token.substring(0, eqIndex) : token;
+        const flag = flags[key];
+        if (flag) {
+            (args[flag] as boolean) = eqIndex > 0 ? token.substring(eqIndex + 1) == 'true' : true;
+            continue;
+        }
+
         const prop = aliases[key];
         if (!prop) throw new Error(`Unknown option: ${token}`);
 
@@ -161,12 +174,13 @@ const main = async () => {
     console.info(NS, 'target =', target);
     console.info(NS, 'region =', config.region);
     console.info(NS, 'profile =', config.profile || '(default credential chain)');
+    console.info(NS, 'useEvent =', args.useEvent);
     console.info(NS, 'payload.type =', typeof payload);
     console.info(NS, 'payload.preview =', $U.S(payload, 720, 96, ' .... '));
 
     const startedAt = Date.now();
     try {
-        const result = await invokeLambda<unknown>(target, payload, { param, config });
+        const result = await invokeLambda<unknown>(target, payload, { param, config, useEvent: args.useEvent });
         console.info(NS, 'success = true');
         console.info(NS, 'elapsed.ms =', Date.now() - startedAt);
         console.info(NS, 'result =', $U.S(result, 1200, 128, ' .... '));


### PR DESCRIPTION
support 'Event' InvocationType in Lambda.

- API Gateway 요청을 받은 Lambda는 바로 응답하고, 오래 걸리는 작업은 다른 Lambda를 비동기로 호출

**example**

```ts
import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";

const lambda = new LambdaClient({});

export const handler = async (event: any) => {
  await lambda.send(
    new InvokeCommand({
      FunctionName: "background-worker",
      InvocationType: "Event", // 비동기 호출
      Payload: Buffer.from(JSON.stringify(event)),
    })
  );

  return {
    statusCode: 202,
    body: JSON.stringify({ ok: true, message: "accepted" }),
  };
};
```